### PR TITLE
Implement commons-cli for all Tool invocation and CLI logic #19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ dependency-reduced-pom.xml
 /bin/
 /core/mudrod.log
 core/maven-eclipse.xml
+service/mudrod.log

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,6 +68,11 @@
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/esiptestbed/mudrod/main/MudrodEngine.java
+++ b/core/src/main/java/esiptestbed/mudrod/main/MudrodEngine.java
@@ -177,7 +177,7 @@ public class MudrodEngine {
     // boolean options
     Option helpOpt = new Option("h", "help", false, "show this help message");
     Option logIngestOpt = new Option("l", LOG_INGEST, false, "begin log ingest with the WeblogDiscoveryEngine only");
-    Option fullIngestOpt = new Option("a", FULL_INGEST, false, "begin full ingest Mudrod workflow");
+    Option fullIngestOpt = new Option("f", FULL_INGEST, false, "begin full ingest Mudrod workflow");
     // argument options
     Option logDirOpt = Option.builder(LOG_DIR).required(true).numberOfArgs(1)
         .hasArg(true).desc("the log directory to be processed by Mudrod").argName(LOG_DIR).build();
@@ -192,15 +192,8 @@ public class MudrodEngine {
     CommandLineParser parser = new DefaultParser();
     try {
       CommandLine line = parser.parse(options, args);
-      if (line.hasOption("help") || !line.hasOption(LOG_DIR)
-          || (!line.hasOption(LOG_INGEST) || !line.hasOption(FULL_INGEST))) {
-        HelpFormatter formatter = new HelpFormatter();
-        formatter.printHelp("MudrodEngine: 'logDir' argument is mandatory. "
-            + "User must also provide either 'logIngest' or 'fullIngest'.", options, true);
-        return;
-      }
       String processingType;
-      if (line.getOptionValue(LOG_INGEST) != null) {
+      if (line.hasOption(LOG_INGEST)) {
         processingType = line.getOptionValue(LOG_INGEST);
       } else {
         processingType = line.getOptionValue(FULL_INGEST);
@@ -227,12 +220,15 @@ public class MudrodEngine {
       }
       me.end();
     } catch (Exception e) {
+      HelpFormatter formatter = new HelpFormatter();
+      formatter.printHelp("MudrodEngine: 'logDir' argument is mandatory. "
+          + "User must also provide either 'logIngest' or 'fullIngest'.", options, true);
       LOG.error("MudrodEngine: 'logDir' argument is mandatory. "
-            + "User must also provide either 'logIngest' or 'fullIngest'.", e);
+          + "User must also provide either 'logIngest' or 'fullIngest'.", e);
       return;
     }
   }
-  
+
   private static void loadFullConfig(MudrodEngine me, String dataDir) {
     me.config.put("ontologyInputDir", dataDir + "SWEET_ocean/");
     me.config.put("oceanTriples", dataDir + "Ocean_triples.csv");

--- a/core/src/main/java/esiptestbed/mudrod/main/MudrodEngine.java
+++ b/core/src/main/java/esiptestbed/mudrod/main/MudrodEngine.java
@@ -19,6 +19,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -35,28 +41,52 @@ import esiptestbed.mudrod.integration.LinkageIntegration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Main entry point for Running the Mudrod system.
+ * Invocation of this class is tightly linked to the primary Mudrod 
+ * configuration which can be located at
+ * <a href="https://github.com/mudrod/mudrod/blob/master/core/src/main/resources/config.xml">config.xml</a>.
+ */
 public class MudrodEngine {
 
   private static final Logger LOG = LoggerFactory.getLogger(MudrodEngine.class);
   private Map<String, String> config = new HashMap<>();
   private ESDriver es = null;
   private SparkDriver spark = null;
+  private static final String LOG_INGEST = "logIngest";
+  private static final String FULL_INGEST = "fullIngest";
+  private static final String LOG_DIR = "logDir";
 
+  /**
+   * Public constructor for this class, loads a default config.xml.
+   */
   public MudrodEngine() {
     loadConfig();
     es = new ESDriver(config);
     spark = new SparkDriver();
-
   }
 
+  /**
+   * Retreive the Mudrod configuration as a {@link java.util.Map}
+   * containing K, V of type String.
+   * @return a configuration {@link java.util.Map}
+   */
   public Map<String, String> getConfig() {
     return config;
   }
 
+  /**
+   * Retreive the Mudrod {@link esiptestbed.mudrod.driver.ESDriver}
+   * @return the {@link esiptestbed.mudrod.driver.ESDriver} instance.
+   */
   public ESDriver getES() {
     return this.es;
   }
 
+  /**
+   * Load the configuration provided at
+   * <a href="https://github.com/mudrod/mudrod/blob/master/core/src/main/resources/config.xml">config.xml</a>.
+   */
   public void loadConfig() {
     SAXBuilder saxBuilder = new SAXBuilder();
     InputStream configStream = MudrodEngine.class.getClassLoader()
@@ -74,13 +104,17 @@ public class MudrodEngine {
             paraNode.getTextTrim());
       }
     } catch (JDOMException e) {
-      e.printStackTrace();
+      LOG.error("Exception whilst processing XML contained within 'config.xml'!", e);
     } catch (IOException e) {
-      e.printStackTrace();
+      LOG.error("Error whilst retrieving and reading 'config.xml' resource!", e);
     }
 
   }
 
+  /**
+   * Preprocess and process various {@link esiptestbed.mudrod.discoveryengine.DiscoveryEngineAbstract}
+   * implementations for weblog, ontology and metadata, linkage discovery and integration.
+   */
   public void start() {
     DiscoveryEngineAbstract wd = new WeblogDiscoveryEngine(config, es, spark);
     wd.preprocess();
@@ -98,6 +132,10 @@ public class MudrodEngine {
     li.execute();
   }
 
+  /**
+   * Only preprocess various {@link esiptestbed.mudrod.discoveryengine.DiscoveryEngineAbstract}
+   * implementations for weblog, ontology and metadata, linkage discovery and integration.
+   */
   public void startProcessing() {
     DiscoveryEngineAbstract wd = new WeblogDiscoveryEngine(config, es, spark);
     wd.process();
@@ -114,57 +152,95 @@ public class MudrodEngine {
     li.execute();
   }
 
+  /**
+   * Begin ingesting logs with the {@link esiptestbed.mudrod.discoveryengine.WeblogDiscoveryEngine}
+   */
   public void startLogIngest() {
     WeblogDiscoveryEngine wd = new WeblogDiscoveryEngine(config, es, spark);
     wd.logIngest();
   }
 
+  /**
+   * Close the connection to the {@link esiptestbed.mudrod.driver.ESDriver} instance.
+   */
   public void end() {
     es.close();
   }
 
+  /**
+   * Main program invocation. Accepts one argument denoting location (on disk)
+   * to a log file which is to be ingested. Help will be provided if invoked
+   * with incorrect parameters.
+   * @param args {@link java.lang.String} array contaning correct parameters.
+   */
   public static void main(String[] args) {
-    if (args.length < 1) {
-      LOG.error("Mudrod Engine expects at least one argument");
+    // boolean options
+    Option helpOpt = new Option("h", "help", false, "show this help message");
+    Option logIngestOpt = new Option("l", LOG_INGEST, false, "begin log ingest with the WeblogDiscoveryEngine only");
+    Option fullIngestOpt = new Option("a", FULL_INGEST, false, "begin full ingest Mudrod workflow");
+    // argument options
+    Option logDirOpt = Option.builder(LOG_DIR).required(true).numberOfArgs(1)
+        .hasArg(true).desc("the log directory to be processed by Mudrod").argName(LOG_DIR).build();
+
+    // create the options
+    Options options = new Options();
+    options.addOption(helpOpt);
+    options.addOption(logIngestOpt);
+    options.addOption(fullIngestOpt);
+    options.addOption(logDirOpt);
+
+    CommandLineParser parser = new DefaultParser();
+    try {
+      CommandLine line = parser.parse(options, args);
+      if (line.hasOption("help") || !line.hasOption(LOG_DIR)
+          || (!line.hasOption(LOG_INGEST) || !line.hasOption(FULL_INGEST))) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp("MudrodEngine: 'logDir' argument is mandatory. "
+            + "User must also provide either 'logIngest' or 'fullIngest'.", options, true);
+        return;
+      }
+      String processingType;
+      if (line.getOptionValue(LOG_INGEST) != null) {
+        processingType = line.getOptionValue(LOG_INGEST);
+      } else {
+        processingType = line.getOptionValue(FULL_INGEST);
+      }
+      String dataDir = line.getOptionValue(LOG_DIR).replace("\\", "/");
+      if(!dataDir.endsWith("/")){
+        dataDir += "/";
+      }
+
+      MudrodEngine me = new MudrodEngine();
+      me.config.put(LOG_DIR, dataDir);
+
+      switch (processingType) {
+      case LOG_INGEST:
+        me.startLogIngest();
+        break;
+      case FULL_INGEST:
+        loadFullConfig(me, dataDir);
+        me.start();
+        me.startProcessing(); 
+        break;
+      default:
+        break;
+      }
+      me.end();
+    } catch (Exception e) {
+      LOG.error("MudrodEngine: 'logDir' argument is mandatory. "
+            + "User must also provide either 'logIngest' or 'fullIngest'.", e);
       return;
     }
-
-    String processingType = args[0];
-    String dataDir = args[1].replace("\\", "/");;
-    if(!dataDir.endsWith("/")){
-      dataDir += "/";
-    }
-
-    MudrodEngine me = new MudrodEngine();
-    me.config.put("logDir", dataDir);
-
-    if(processingType.equals("LogIngest"))
-    {
-      me.startLogIngest();    
-    }
-
-    if(processingType.equals("All")||processingType.equals("Processing"))
-    {
-      me.config.put("ontologyInputDir", dataDir + "SWEET_ocean/");
-      me.config.put("oceanTriples", dataDir + "Ocean_triples.csv");
-
-      me.config.put("userHistoryMatrix", dataDir + "UserHistoryMatrix.csv");
-      me.config.put("clickstreamMatrix", dataDir + "ClickstreamMatrix.csv");
-      me.config.put("metadataMatrix", dataDir + "MetadataMatrix.csv");
-
-      me.config.put("clickstreamSVDMatrix_tmp", dataDir + "clickstreamSVDMatrix_tmp.csv");
-      me.config.put("metadataSVDMatrix_tmp", dataDir + "metadataSVDMatrix_tmp.csv");
-
-      me.config.put("raw_metadataPath", dataDir + "RawMetadata");
-
-      if(processingType.equals("All"))
-        me.start(); 
-
-      if(processingType.equals("Processing"))
-        me.startProcessing(); 
-    }
-
-
-    me.end();
+  }
+  
+  private static void loadFullConfig(MudrodEngine me, String dataDir) {
+    me.config.put("ontologyInputDir", dataDir + "SWEET_ocean/");
+    me.config.put("oceanTriples", dataDir + "Ocean_triples.csv");
+    me.config.put("userHistoryMatrix", dataDir + "UserHistoryMatrix.csv");
+    me.config.put("clickstreamMatrix", dataDir + "ClickstreamMatrix.csv");
+    me.config.put("metadataMatrix", dataDir + "MetadataMatrix.csv");
+    me.config.put("clickstreamSVDMatrix_tmp", dataDir + "clickstreamSVDMatrix_tmp.csv");
+    me.config.put("metadataSVDMatrix_tmp", dataDir + "metadataSVDMatrix_tmp.csv");
+    me.config.put("raw_metadataPath", dataDir + "RawMetadata");
   }
 }

--- a/core/src/main/java/esiptestbed/mudrod/main/package-info.java
+++ b/core/src/main/java/esiptestbed/mudrod/main/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you 
+ * may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Main entry point for Running the Mudrod system.
+ */
+package esiptestbed.mudrod.main;

--- a/core/src/main/resources/log4j.properties
+++ b/core/src/main/resources/log4j.properties
@@ -21,7 +21,7 @@ log4j.threshhold=ALL
 log4j.rootLogger=${mudrod.root.logger}
 
 #special logging requirements for some commandline tools
-#log4j.logger.org.apache.mudrod...=INFO,console
+log4j.logger.esiptestbed.mudrod.main.MudrodEngine=INFO,console
 
 #
 # Daily Rolling File Appender

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,11 @@
         <version>1.2.17</version>
         <!--scope>runtime</scope-->
       </dependency>
+      <dependency>
+        <groupId>commons-cli</groupId>
+        <artifactId>commons-cli</artifactId>
+        <version>1.3.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
@Yongyao @quintinali this PR addresses part of #19, I will also update it with the correct CLI implementation for the [ImportLogFile](https://github.com/mudrod/mudrod/blob/master/core/src/main/java/esiptestbed/mudrod/weblog/pre/ImportLogFile.java) tool. Update coming. 
To give you an idea of what this will now look like, MudrodEngine should be invoked with the following help.

```
usage: MudrodEngine: 'logDir' argument is mandatory. User must also
       provide either 'logIngest' or 'fullIngest'. [-a] [-h] [-l] -logDir
       <logDir>
 -f,--fullIngest    begin full ingest Mudrod workflow
 -h,--help          show this help message
 -l,--logIngest     begin log ingest with the WeblogDiscoveryEngine only
 -logDir <logDir>   the log directory to be processed by Mudrod
ERROR main.MudrodEngine              - MudrodEngine: 'logDir' argument is mandatory. User must also provide either 'logIngest' or 'fullIngest'.
org.apache.commons.cli.MissingOptionException: Missing required option: logDir
    at org.apache.commons.cli.DefaultParser.checkRequiredOptions(DefaultParser.java:199)
    at org.apache.commons.cli.DefaultParser.parse(DefaultParser.java:130)
    at org.apache.commons.cli.DefaultParser.parse(DefaultParser.java:76)
    at org.apache.commons.cli.DefaultParser.parse(DefaultParser.java:60)
    at esiptestbed.mudrod.main.MudrodEngine.main(MudrodEngine.java:194)
```
