### PR TITLE
Fix for Mudrod 119

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -142,6 +142,16 @@
             <resource>
                 <directory>${basedir}/src/main/resources</directory>
                 <filtering>true</filtering>
+                <excludes>
+                    <exclude>javaSVMWithSGDModel/**</exclude>
+                </excludes>
+            </resource>
+
+            <resource>
+                <directory>${project.build.directory}</directory>
+                <includes>
+                    <include>javaSVMWithSGDModel.tar.gz</include>
+                </includes>
             </resource>
 
             <resource>
@@ -186,14 +196,44 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.6</version>
-                <configuration>
-                    <appendAssemblyId>false</appendAssemblyId>
-                    <tarLongFileMode>posix</tarLongFileMode>
-                    <descriptors>
-                        <descriptor>${basedir}/src/main/assembly/bin.xml
-                        </descriptor>
-                    </descriptors>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>zipSVMWithSGDModel</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <tarLongFileMode>posix</tarLongFileMode>
+                            <finalName>javaSVMWithSGDModel</finalName>
+                            <outputDirectory>${project.build.directory}
+                            </outputDirectory>
+                            <descriptors>
+                                <descriptor>
+                                    ${basedir}/src/main/assembly/zipSVMWithSGDModel.xml
+                                </descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>generateDistribution</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <tarLongFileMode>posix</tarLongFileMode>
+                            <descriptors>
+                                <descriptor>
+                                    ${basedir}/src/main/assembly/bin.xml
+                                </descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/core/src/main/assembly/zipSVMWithSGDModel.xml
+++ b/core/src/main/assembly/zipSVMWithSGDModel.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain  a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0 Unless
+
+  required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS"
+  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+-->
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>zipSVMWithSGDModel</id>
+    <baseDirectory>javaSVMWithSGDModel</baseDirectory>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/resources/javaSVMWithSGDModel</directory>
+            <outputDirectory>.</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/DiscoveryEngineAbstract.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/DiscoveryEngineAbstract.java
@@ -19,15 +19,13 @@ import gov.nasa.jpl.mudrod.driver.SparkDriver;
 import java.io.Serializable;
 import java.util.Properties;
 
-public abstract class DiscoveryEngineAbstract extends MudrodAbstract
-    implements Serializable {
+public abstract class DiscoveryEngineAbstract extends MudrodAbstract implements Serializable {
   /**
    *
    */
   private static final long serialVersionUID = 1L;
 
-  public DiscoveryEngineAbstract(Properties props, ESDriver es,
-      SparkDriver spark) {
+  public DiscoveryEngineAbstract(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
   }
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/DiscoveryStepAbstract.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/DiscoveryStepAbstract.java
@@ -23,8 +23,7 @@ import java.util.Properties;
  */
 public abstract class DiscoveryStepAbstract extends MudrodAbstract {
 
-  public DiscoveryStepAbstract(Properties props, ESDriver es,
-      SparkDriver spark) {
+  public DiscoveryStepAbstract(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
   }
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/MetadataDiscoveryEngine.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/MetadataDiscoveryEngine.java
@@ -27,18 +27,15 @@ import java.util.Properties;
 /**
  * Supports to preprocess and process metadata
  */
-public class MetadataDiscoveryEngine extends DiscoveryEngineAbstract
-    implements Serializable {
+public class MetadataDiscoveryEngine extends DiscoveryEngineAbstract implements Serializable {
 
   /**
    *
    */
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(MetadataDiscoveryEngine.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataDiscoveryEngine.class);
 
-  public MetadataDiscoveryEngine(Properties props, ESDriver es,
-      SparkDriver spark) {
+  public MetadataDiscoveryEngine(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
   }
 
@@ -46,18 +43,14 @@ public class MetadataDiscoveryEngine extends DiscoveryEngineAbstract
    * Method of preprocessing metadata
    */
   public void preprocess() {
-    LOG.info(
-        "*****************Metadata preprocessing starts******************");
+    LOG.info("*****************Metadata preprocessing starts******************");
     startTime = System.currentTimeMillis();
 
-    DiscoveryStepAbstract harvester = new ApiHarvester(this.props, this.es,
-        this.spark);
+    DiscoveryStepAbstract harvester = new ApiHarvester(this.props, this.es, this.spark);
     harvester.execute();
 
     endTime = System.currentTimeMillis();
-    LOG.info(
-        "*****************Metadata preprocessing ends******************Took {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************Metadata preprocessing ends******************Took {}s", (endTime - startTime) / 1000);
   }
 
   /**
@@ -67,18 +60,14 @@ public class MetadataDiscoveryEngine extends DiscoveryEngineAbstract
     LOG.info("*****************Metadata processing starts******************");
     startTime = System.currentTimeMillis();
 
-    DiscoveryStepAbstract matrix = new MatrixGenerator(this.props, this.es,
-        this.spark);
+    DiscoveryStepAbstract matrix = new MatrixGenerator(this.props, this.es, this.spark);
     matrix.execute();
 
-    DiscoveryStepAbstract svd = new MetadataAnalyzer(this.props, this.es,
-        this.spark);
+    DiscoveryStepAbstract svd = new MetadataAnalyzer(this.props, this.es, this.spark);
     svd.execute();
 
     endTime = System.currentTimeMillis();
-    LOG.info(
-        "*****************Metadata processing ends******************Took {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************Metadata processing ends******************Took {}s", (endTime - startTime) / 1000);
   }
 
   public void output() {

--- a/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/MudrodAbstract.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/MudrodAbstract.java
@@ -33,8 +33,7 @@ import java.util.Properties;
  */
 public abstract class MudrodAbstract implements Serializable {
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(MudrodAbstract.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MudrodAbstract.class);
   /**
    *
    */
@@ -63,10 +62,8 @@ public abstract class MudrodAbstract implements Serializable {
    */
   @CheckForNull
   protected void initMudrod() {
-    InputStream settingsStream = getClass().getClassLoader()
-        .getResourceAsStream(ES_SETTINGS);
-    InputStream mappingsStream = getClass().getClassLoader()
-        .getResourceAsStream(ES_MAPPINGS);
+    InputStream settingsStream = getClass().getClassLoader().getResourceAsStream(ES_SETTINGS);
+    InputStream mappingsStream = getClass().getClassLoader().getResourceAsStream(ES_MAPPINGS);
     JSONObject settingsJSON = null;
     JSONObject mappingJSON = null;
 
@@ -84,8 +81,7 @@ public abstract class MudrodAbstract implements Serializable {
 
     try {
       if (settingsJSON != null && mappingJSON != null) {
-        this.es.putMapping(props.getProperty(MudrodConstants.ES_INDEX_NAME),
-            settingsJSON.toString(), mappingJSON.toString());
+        this.es.putMapping(props.getProperty(MudrodConstants.ES_INDEX_NAME), settingsJSON.toString(), mappingJSON.toString());
       }
     } catch (IOException e) {
       LOG.error("Error entering Elasticsearch Mappings!", e);

--- a/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/OntologyDiscoveryEngine.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/OntologyDiscoveryEngine.java
@@ -31,11 +31,9 @@ public class OntologyDiscoveryEngine extends DiscoveryEngineAbstract {
    *
    */
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(OntologyDiscoveryEngine.class);
+  private static final Logger LOG = LoggerFactory.getLogger(OntologyDiscoveryEngine.class);
 
-  public OntologyDiscoveryEngine(Properties props, ESDriver es,
-      SparkDriver spark) {
+  public OntologyDiscoveryEngine(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
   }
 
@@ -43,18 +41,14 @@ public class OntologyDiscoveryEngine extends DiscoveryEngineAbstract {
    * Method of preprocessing ontology
    */
   public void preprocess() {
-    LOG.info(
-        "*****************Ontology preprocessing starts******************");
+    LOG.info("*****************Ontology preprocessing starts******************");
     startTime = System.currentTimeMillis();
 
-    DiscoveryStepAbstract at = new AggregateTriples(this.props, this.es,
-        this.spark);
+    DiscoveryStepAbstract at = new AggregateTriples(this.props, this.es, this.spark);
     at.execute();
 
     endTime = System.currentTimeMillis();
-    LOG.info(
-        "*****************Ontology preprocessing ends******************Took {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************Ontology preprocessing ends******************Took {}s", (endTime - startTime) / 1000);
   }
 
   /**
@@ -64,14 +58,11 @@ public class OntologyDiscoveryEngine extends DiscoveryEngineAbstract {
     LOG.info("*****************Ontology processing starts******************");
     startTime = System.currentTimeMillis();
 
-    DiscoveryStepAbstract ol = new OntologyLinkCal(this.props, this.es,
-        this.spark);
+    DiscoveryStepAbstract ol = new OntologyLinkCal(this.props, this.es, this.spark);
     ol.execute();
 
     endTime = System.currentTimeMillis();
-    LOG.info(
-        "*****************Ontology processing ends******************Took {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************Ontology processing ends******************Took {}s", (endTime - startTime) / 1000);
   }
 
   public void output() {

--- a/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/RecommendEngine.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/RecommendEngine.java
@@ -17,8 +17,7 @@ import java.util.Properties;
 public class RecommendEngine extends DiscoveryEngineAbstract {
 
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(RecommendEngine.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RecommendEngine.class);
 
   public RecommendEngine(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
@@ -29,59 +28,46 @@ public class RecommendEngine extends DiscoveryEngineAbstract {
   @Override
   public void preprocess() {
     // TODO Auto-generated method stub
-    LOG.info(
-        "*****************Recommendation preprocessing starts******************");
+    LOG.info("*****************Recommendation preprocessing starts******************");
 
     startTime = System.currentTimeMillis();
 
-    DiscoveryStepAbstract harvester = new ImportMetadata(this.props, this.es,
-        this.spark);
+    DiscoveryStepAbstract harvester = new ImportMetadata(this.props, this.es, this.spark);
     harvester.execute();
 
-    DiscoveryStepAbstract tfidf = new MetadataTFIDFGenerator(this.props,
-        this.es, this.spark);
+    DiscoveryStepAbstract tfidf = new MetadataTFIDFGenerator(this.props, this.es, this.spark);
     tfidf.execute();
 
-    DiscoveryStepAbstract sessionMatrixGen = new SessionCooccurence(this.props,
-        this.es, this.spark);
+    DiscoveryStepAbstract sessionMatrixGen = new SessionCooccurence(this.props, this.es, this.spark);
     sessionMatrixGen.execute();
 
-    DiscoveryStepAbstract transformer = new NormalizeVariables(this.props,
-        this.es, this.spark);
+    DiscoveryStepAbstract transformer = new NormalizeVariables(this.props, this.es, this.spark);
     transformer.execute();
 
     endTime = System.currentTimeMillis();
 
-    LOG.info(
-        "*****************Recommendation preprocessing  ends******************Took {}s {}",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************Recommendation preprocessing  ends******************Took {}s {}", (endTime - startTime) / 1000);
   }
 
   @Override
   public void process() {
     // TODO Auto-generated method stub
-    LOG.info(
-        "*****************Recommendation processing starts******************");
+    LOG.info("*****************Recommendation processing starts******************");
 
     startTime = System.currentTimeMillis();
 
-    DiscoveryStepAbstract tfCF = new AbstractBasedSimilarity(this.props,
-        this.es, this.spark);
+    DiscoveryStepAbstract tfCF = new AbstractBasedSimilarity(this.props, this.es, this.spark);
     tfCF.execute();
 
-    DiscoveryStepAbstract cbCF = new VariableBasedSimilarity(this.props,
-        this.es, this.spark);
+    DiscoveryStepAbstract cbCF = new VariableBasedSimilarity(this.props, this.es, this.spark);
     cbCF.execute();
 
-    DiscoveryStepAbstract sbCF = new sessionBasedCF(this.props, this.es,
-        this.spark);
+    DiscoveryStepAbstract sbCF = new sessionBasedCF(this.props, this.es, this.spark);
     sbCF.execute();
 
     endTime = System.currentTimeMillis();
 
-    LOG.info(
-        "*****************Recommendation processing ends******************Took {}s {}",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************Recommendation processing ends******************Took {}s {}", (endTime - startTime) / 1000);
   }
 
   @Override

--- a/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/WeblogDiscoveryEngine.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/discoveryengine/WeblogDiscoveryEngine.java
@@ -43,12 +43,10 @@ public class WeblogDiscoveryEngine extends DiscoveryEngineAbstract {
    *
    */
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(WeblogDiscoveryEngine.class);
+  private static final Logger LOG = LoggerFactory.getLogger(WeblogDiscoveryEngine.class);
   public String timeSuffix = null;
 
-  public WeblogDiscoveryEngine(Properties props, ESDriver es,
-      SparkDriver spark) {
+  public WeblogDiscoveryEngine(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
     LOG.info("Started Mudrod Weblog Discovery Engine.");
   }
@@ -66,11 +64,8 @@ public class WeblogDiscoveryEngine extends DiscoveryEngineAbstract {
       File directory = new File(logDir);
       File[] fList = directory.listFiles();
       for (File file : fList) {
-        if (file.isFile() && file.getName().matches(".*\\d+.*") && file
-            .getName()
-            .contains(props.getProperty(MudrodConstants.HTTP_PREFIX))) {
-          inputList.add(file.getName()
-              .replace(props.getProperty(MudrodConstants.HTTP_PREFIX), ""));
+        if (file.isFile() && file.getName().matches(".*\\d+.*") && file.getName().contains(props.getProperty(MudrodConstants.HTTP_PREFIX))) {
+          inputList.add(file.getName().replace(props.getProperty(MudrodConstants.HTTP_PREFIX), ""));
         }
       }
     } else {
@@ -80,8 +75,7 @@ public class WeblogDiscoveryEngine extends DiscoveryEngineAbstract {
         fileStatus = fs.listStatus(new Path(logDir));
         for (FileStatus status : fileStatus) {
           String path1 = status.getPath().toString();
-          if (path1.matches(".*\\d+.*") && path1
-              .contains(props.getProperty(MudrodConstants.HTTP_PREFIX))) {
+          if (path1.matches(".*\\d+.*") && path1.contains(props.getProperty(MudrodConstants.HTTP_PREFIX))) {
 
             String time = path1.substring(path1.lastIndexOf('.') + 1);
             inputList.add(time);
@@ -103,8 +97,7 @@ public class WeblogDiscoveryEngine extends DiscoveryEngineAbstract {
   public void preprocess() {
     LOG.info("Starting Web log preprocessing.");
 
-    ArrayList<String> inputList = (ArrayList<String>) getFileList(
-        props.getProperty(MudrodConstants.LOG_DIR));
+    ArrayList<String> inputList = (ArrayList<String>) getFileList(props.getProperty(MudrodConstants.LOG_DIR));
 
     for (int i = 0; i < inputList.size(); i++) {
       timeSuffix = inputList.get(i);
@@ -112,39 +105,30 @@ public class WeblogDiscoveryEngine extends DiscoveryEngineAbstract {
       startTime = System.currentTimeMillis();
       LOG.info("Processing logs dated {}", inputList.get(i));
 
-      DiscoveryStepAbstract im = new ImportLogFile(this.props, this.es,
-          this.spark);
+      DiscoveryStepAbstract im = new ImportLogFile(this.props, this.es, this.spark);
       im.execute();
 
-      DiscoveryStepAbstract cd = new CrawlerDetection(this.props, this.es,
-          this.spark);
+      DiscoveryStepAbstract cd = new CrawlerDetection(this.props, this.es, this.spark);
       cd.execute();
 
-      DiscoveryStepAbstract sg = new SessionGenerator(this.props, this.es,
-          this.spark);
+      DiscoveryStepAbstract sg = new SessionGenerator(this.props, this.es, this.spark);
       sg.execute();
 
-      DiscoveryStepAbstract ss = new SessionStatistic(this.props, this.es,
-          this.spark);
+      DiscoveryStepAbstract ss = new SessionStatistic(this.props, this.es, this.spark);
       ss.execute();
 
-      DiscoveryStepAbstract rr = new RemoveRawLog(this.props, this.es,
-          this.spark);
+      DiscoveryStepAbstract rr = new RemoveRawLog(this.props, this.es, this.spark);
       rr.execute();
 
       endTime = System.currentTimeMillis();
 
-      LOG.info(
-          "Web log preprocessing for logs dated {} complete. Time elapsed {} seconds.",
-          inputList.get(i), (endTime - startTime) / 1000);
+      LOG.info("Web log preprocessing for logs dated {} complete. Time elapsed {} seconds.", inputList.get(i), (endTime - startTime) / 1000);
     }
 
-    DiscoveryStepAbstract hg = new HistoryGenerator(this.props, this.es,
-        this.spark);
+    DiscoveryStepAbstract hg = new HistoryGenerator(this.props, this.es, this.spark);
     hg.execute();
 
-    DiscoveryStepAbstract cg = new ClickStreamGenerator(this.props, this.es,
-        this.spark);
+    DiscoveryStepAbstract cg = new ClickStreamGenerator(this.props, this.es, this.spark);
     cg.execute();
 
     LOG.info("Web log preprocessing (user history and clickstream) complete.");
@@ -155,13 +139,11 @@ public class WeblogDiscoveryEngine extends DiscoveryEngineAbstract {
    */
   public void logIngest() {
     LOG.info("Starting Web log ingest.");
-    ArrayList<String> inputList = (ArrayList<String>) getFileList(
-        props.getProperty(MudrodConstants.LOG_DIR));
+    ArrayList<String> inputList = (ArrayList<String>) getFileList(props.getProperty(MudrodConstants.LOG_DIR));
     for (int i = 0; i < inputList.size(); i++) {
       timeSuffix = inputList.get(i);
       props.put("TimeSuffix", timeSuffix);
-      DiscoveryStepAbstract im = new ImportLogFile(this.props, this.es,
-          this.spark);
+      DiscoveryStepAbstract im = new ImportLogFile(this.props, this.es, this.spark);
       im.execute();
     }
 
@@ -174,25 +156,20 @@ public class WeblogDiscoveryEngine extends DiscoveryEngineAbstract {
    */
   public void sessionRestruct() {
     LOG.info("Starting Session reconstruction.");
-    ArrayList<String> inputList = (ArrayList<String>) getFileList(
-        props.getProperty(MudrodConstants.LOG_DIR));
+    ArrayList<String> inputList = (ArrayList<String>) getFileList(props.getProperty(MudrodConstants.LOG_DIR));
     for (int i = 0; i < inputList.size(); i++) {
       timeSuffix = inputList.get(i); // change timeSuffix dynamically
       props.put(MudrodConstants.TIME_SUFFIX, timeSuffix);
-      DiscoveryStepAbstract cd = new CrawlerDetection(this.props, this.es,
-          this.spark);
+      DiscoveryStepAbstract cd = new CrawlerDetection(this.props, this.es, this.spark);
       cd.execute();
 
-      DiscoveryStepAbstract sg = new SessionGenerator(this.props, this.es,
-          this.spark);
+      DiscoveryStepAbstract sg = new SessionGenerator(this.props, this.es, this.spark);
       sg.execute();
 
-      DiscoveryStepAbstract ss = new SessionStatistic(this.props, this.es,
-          this.spark);
+      DiscoveryStepAbstract ss = new SessionStatistic(this.props, this.es, this.spark);
       ss.execute();
 
-      DiscoveryStepAbstract rr = new RemoveRawLog(this.props, this.es,
-          this.spark);
+      DiscoveryStepAbstract rr = new RemoveRawLog(this.props, this.es, this.spark);
       rr.execute();
 
       endTime = System.currentTimeMillis();
@@ -205,17 +182,14 @@ public class WeblogDiscoveryEngine extends DiscoveryEngineAbstract {
     LOG.info("Starting Web log processing.");
     startTime = System.currentTimeMillis();
 
-    DiscoveryStepAbstract svd = new ClickStreamAnalyzer(this.props, this.es,
-        this.spark);
+    DiscoveryStepAbstract svd = new ClickStreamAnalyzer(this.props, this.es, this.spark);
     svd.execute();
 
-    DiscoveryStepAbstract ua = new UserHistoryAnalyzer(this.props, this.es,
-        this.spark);
+    DiscoveryStepAbstract ua = new UserHistoryAnalyzer(this.props, this.es, this.spark);
     ua.execute();
 
     endTime = System.currentTimeMillis();
-    LOG.info("Web log processing complete. Time elaspsed {} seconds.",
-        (endTime - startTime) / 1000);
+    LOG.info("Web log processing complete. Time elaspsed {} seconds.", (endTime - startTime) / 1000);
   }
 
   @Override

--- a/core/src/main/java/gov/nasa/jpl/mudrod/driver/SparkDriver.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/driver/SparkDriver.java
@@ -66,12 +66,8 @@ public class SparkDriver implements Serializable {
   }
 
   public SparkDriver(Properties props) {
-    SparkConf conf = new SparkConf().setAppName(
-        props.getProperty(MudrodConstants.SPARK_APP_NAME, "MudrodSparkApp"))
-        .setIfMissing("spark.master",
-            props.getProperty(MudrodConstants.SPARK_MASTER))
-        .set("spark.hadoop.validateOutputSpecs", "false")
-        .set("spark.files.overwrite", "true");
+    SparkConf conf = new SparkConf().setAppName(props.getProperty(MudrodConstants.SPARK_APP_NAME, "MudrodSparkApp")).setIfMissing("spark.master", props.getProperty(MudrodConstants.SPARK_MASTER))
+        .set("spark.hadoop.validateOutputSpecs", "false").set("spark.files.overwrite", "true");
 
     String esHost = props.getProperty(MudrodConstants.ES_UNICAST_HOSTS);
     String esPort = props.getProperty(MudrodConstants.ES_HTTP_PORT);

--- a/core/src/main/java/gov/nasa/jpl/mudrod/integration/LinkageIntegration.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/integration/LinkageIntegration.java
@@ -37,8 +37,7 @@ import java.util.stream.Collectors;
  */
 public class LinkageIntegration extends DiscoveryStepAbstract {
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(LinkageIntegration.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LinkageIntegration.class);
   private static final long serialVersionUID = 1L;
   transient List<LinkedTerm> termList = new ArrayList<>();
   DecimalFormat df = new DecimalFormat("#.00");
@@ -90,8 +89,7 @@ public class LinkageIntegration extends DiscoveryStepAbstract {
     Map<String, Double> termsMap = new HashMap<>();
     Map<String, List<LinkedTerm>> map = new HashMap<>();
     try {
-      map = aggregateRelatedTermsFromAllmodel(
-          es.customAnalyzing(props.getProperty(INDEX_NAME), input));
+      map = aggregateRelatedTermsFromAllmodel(es.customAnalyzing(props.getProperty(INDEX_NAME), input));
     } catch (InterruptedException | ExecutionException e) {
       LOG.error("Error applying majority rule", e);
     }
@@ -139,8 +137,7 @@ public class LinkageIntegration extends DiscoveryStepAbstract {
       }
       count++;
     }
-    LOG.info(
-        "\n************************Integrated results***************************");
+    LOG.info("\n************************Integrated results***************************");
     LOG.info(output);
     return output;
   }
@@ -174,8 +171,7 @@ public class LinkageIntegration extends DiscoveryStepAbstract {
    * @return a hash map where the string is a related term, and the list is
    * the similarities from different sources
    */
-  public Map<String, List<LinkedTerm>> aggregateRelatedTermsFromAllmodel(
-      String input) {
+  public Map<String, List<LinkedTerm>> aggregateRelatedTermsFromAllmodel(String input) {
     aggregateRelatedTerms(input, props.getProperty("userHistoryLinkageType"));
     aggregateRelatedTerms(input, props.getProperty("clickStreamLinkageType"));
     aggregateRelatedTerms(input, props.getProperty("metadataLinkageType"));
@@ -222,21 +218,17 @@ public class LinkageIntegration extends DiscoveryStepAbstract {
 
   public void aggregateRelatedTerms(String input, String model) {
     //get the first 10 related terms
-    SearchResponse usrhis = es.getClient()
-        .prepareSearch(props.getProperty(INDEX_NAME)).setTypes(model)
-        .setQuery(QueryBuilders.termQuery("keywords", input))
-        .addSort(WEIGHT, SortOrder.DESC).setSize(11).execute().actionGet();
+    SearchResponse usrhis = es.getClient().prepareSearch(props.getProperty(INDEX_NAME)).setTypes(model).setQuery(QueryBuilders.termQuery("keywords", input)).addSort(WEIGHT, SortOrder.DESC).setSize(11)
+        .execute().actionGet();
 
-    LOG.info("\n************************ {} results***************************",
-        model);
+    LOG.info("\n************************ {} results***************************", model);
     for (SearchHit hit : usrhis.getHits().getHits()) {
       Map<String, Object> result = hit.getSource();
       String keywords = (String) result.get("keywords");
       String relatedKey = extractRelated(keywords, input);
 
       if (!relatedKey.equals(input)) {
-        LinkedTerm lTerm = new LinkedTerm(relatedKey,
-            (double) result.get(WEIGHT), model);
+        LinkedTerm lTerm = new LinkedTerm(relatedKey, (double) result.get(WEIGHT), model);
         LOG.info("( {} {} )", relatedKey, (double) result.get(WEIGHT));
         termList.add(lTerm);
       }
@@ -251,18 +243,14 @@ public class LinkageIntegration extends DiscoveryStepAbstract {
    * @param model source name
    */
   public void aggregateRelatedTermsSWEET(String input, String model) {
-    SearchResponse usrhis = es.getClient()
-        .prepareSearch(props.getProperty(INDEX_NAME)).setTypes(model)
-        .setQuery(QueryBuilders.termQuery("concept_A", input))
-        .addSort(WEIGHT, SortOrder.DESC).setSize(11).execute().actionGet();
-    LOG.info("\n************************ {} results***************************",
-        model);
+    SearchResponse usrhis = es.getClient().prepareSearch(props.getProperty(INDEX_NAME)).setTypes(model).setQuery(QueryBuilders.termQuery("concept_A", input)).addSort(WEIGHT, SortOrder.DESC)
+        .setSize(11).execute().actionGet();
+    LOG.info("\n************************ {} results***************************", model);
     for (SearchHit hit : usrhis.getHits().getHits()) {
       Map<String, Object> result = hit.getSource();
       String conceptB = (String) result.get("concept_B");
       if (!conceptB.equals(input)) {
-        LinkedTerm lTerm = new LinkedTerm(conceptB, (double) result.get(WEIGHT),
-            model);
+        LinkedTerm lTerm = new LinkedTerm(conceptB, (double) result.get(WEIGHT), model);
         LOG.info("( {} {} )", conceptB, (double) result.get(WEIGHT));
         termList.add(lTerm);
       }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/main/MudrodEngine.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/main/MudrodEngine.java
@@ -18,6 +18,11 @@ import gov.nasa.jpl.mudrod.driver.ESDriver;
 import gov.nasa.jpl.mudrod.driver.SparkDriver;
 import gov.nasa.jpl.mudrod.integration.LinkageIntegration;
 import org.apache.commons.cli.*;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -25,10 +30,10 @@ import org.jdom2.input.SAXBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
 import java.util.Properties;
 
@@ -113,10 +118,7 @@ public class MudrodEngine {
 
   private InputStream locateConfig() {
 
-    String configLocation =
-        System.getenv(MudrodConstants.MUDROD_CONFIG) == null ?
-            "" :
-            System.getenv(MudrodConstants.MUDROD_CONFIG);
+    String configLocation = System.getenv(MudrodConstants.MUDROD_CONFIG) == null ? "" : System.getenv(MudrodConstants.MUDROD_CONFIG);
     File configFile = new File(configLocation);
 
     try {
@@ -124,17 +126,13 @@ public class MudrodEngine {
       LOG.info("Loaded config file from " + configFile.getAbsolutePath());
       return configStream;
     } catch (IOException e) {
-      LOG.info("File specified by environment variable "
-          + MudrodConstants.MUDROD_CONFIG + "=\'" + configLocation
-          + "\' could not be loaded. " + e.getMessage());
+      LOG.info("File specified by environment variable " + MudrodConstants.MUDROD_CONFIG + "=\'" + configLocation + "\' could not be loaded. " + e.getMessage());
     }
 
-    InputStream configStream = MudrodEngine.class.getClassLoader()
-        .getResourceAsStream("config.xml");
+    InputStream configStream = MudrodEngine.class.getClassLoader().getResourceAsStream("config.xml");
 
     if (configStream != null) {
-      LOG.info("Loaded config file from " + MudrodEngine.class.getClassLoader()
-          .getResource("config.xml").getPath());
+      LOG.info("Loaded config file from " + MudrodEngine.class.getClassLoader().getResource("config.xml").getPath());
     }
 
     return configStream;
@@ -159,15 +157,58 @@ public class MudrodEngine {
 
       for (int i = 0; i < paraList.size(); i++) {
         Element paraNode = paraList.get(i);
-        props.put(paraNode.getAttributeValue("name"), paraNode.getTextTrim());
+        String attributeName = paraNode.getAttributeValue("name");
+        if (MudrodConstants.SVM_SGD_MODEL.equals(attributeName)) {
+          props.put(attributeName, decompressSVMWithSGDModel(paraNode.getTextTrim()));
+        } else {
+          props.put(attributeName, paraNode.getTextTrim());
+        }
       }
     } catch (JDOMException | IOException e) {
-      LOG.error(
-          "Exception whilst retreiving or processing XML contained within 'config.xml'!",
-          e);
+      LOG.error("Exception whilst retrieving or processing XML contained within 'config.xml'!", e);
     }
     return getConfig();
 
+  }
+
+  private String decompressSVMWithSGDModel(String archiveName) throws IOException {
+
+    URL scmArchive = getClass().getClassLoader().getResource(archiveName);
+    if (scmArchive == null) {
+      throw new IOException("Unable to locate " + archiveName + " as a classpath resource.");
+    }
+    File tempDir = Files.createTempDirectory("mudrod", PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrw----"))).toFile();
+    File archiveFile = new File(tempDir, archiveName);
+    FileUtils.copyURLToFile(scmArchive, archiveFile);
+
+    // Decompress archive
+    int BUFFER_SIZE = 512000;
+    GzipCompressorInputStream gzipIn = new GzipCompressorInputStream(new FileInputStream(archiveFile));
+    try (TarArchiveInputStream tarIn = new TarArchiveInputStream(gzipIn)) {
+      TarArchiveEntry entry;
+
+      while ((entry = (TarArchiveEntry) tarIn.getNextEntry()) != null) {
+        // If the entry is a directory, create the directory.
+        if (entry.isDirectory()) {
+          File f = new File(tempDir, entry.getName());
+          boolean created = f.mkdir();
+          if (!created) {
+            LOG.error("Unable to create directory '%s', during extraction of archive contents.", f.getAbsolutePath());
+          }
+        } else {
+          int count;
+          byte data[] = new byte[BUFFER_SIZE];
+          FileOutputStream fos = new FileOutputStream(new File(tempDir, entry.getName()), false);
+          try (BufferedOutputStream dest = new BufferedOutputStream(fos, BUFFER_SIZE)) {
+            while ((count = tarIn.read(data, 0, BUFFER_SIZE)) != -1) {
+              dest.write(data, 0, count);
+            }
+          }
+        }
+      }
+    }
+
+    return new File(tempDir, StringUtils.removeEnd(archiveName, ".tar.gz")).toURI().toString();
   }
 
   /**
@@ -234,8 +275,7 @@ public class MudrodEngine {
     DiscoveryEngineAbstract md = new MetadataDiscoveryEngine(props, es, spark);
     md.preprocess();
     md.process();
-    LOG.info("*****************Ontology and metadata similarity have "
-        + "been added successfully******************");
+    LOG.info("*****************Ontology and metadata similarity have " + "been added successfully******************");
   }
 
   /**
@@ -294,44 +334,31 @@ public class MudrodEngine {
     Option helpOpt = new Option("h", "help", false, "show this help message");
 
     // preprocessing + processing
-    Option fullIngestOpt = new Option("f", FULL_INGEST, false,
-        "begin full ingest Mudrod workflow");
+    Option fullIngestOpt = new Option("f", FULL_INGEST, false, "begin full ingest Mudrod workflow");
     // processing only, assuming that preprocessing results is in logDir
-    Option processingOpt = new Option("p", PROCESSING, false,
-        "begin processing with preprocessing results");
+    Option processingOpt = new Option("p", PROCESSING, false, "begin processing with preprocessing results");
 
     // import raw web log into Elasticsearch
-    Option logIngestOpt = new Option("l", LOG_INGEST, false,
-        "begin log ingest without any processing only");
+    Option logIngestOpt = new Option("l", LOG_INGEST, false, "begin log ingest without any processing only");
     // preprocessing web log, assuming web log has already been imported
-    Option sessionReconOpt = new Option("s", SESSION_RECON, false,
-        "begin session reconstruction");
+    Option sessionReconOpt = new Option("s", SESSION_RECON, false, "begin session reconstruction");
     // calculate vocab similarity from session reconstrution results
-    Option vocabSimFromOpt = new Option("v", VOCAB_SIM_FROM_LOG, false,
-        "begin similarity calulation from web log Mudrod workflow");
+    Option vocabSimFromOpt = new Option("v", VOCAB_SIM_FROM_LOG, false, "begin similarity calulation from web log Mudrod workflow");
     // add metadata and ontology preprocessing and processing results into web
     // log vocab similarity
-    Option addMetaOntoOpt = new Option("a", ADD_META_ONTO, false,
-        "begin adding metadata and ontology results");
+    Option addMetaOntoOpt = new Option("a", ADD_META_ONTO, false, "begin adding metadata and ontology results");
 
     // argument options
-    Option logDirOpt = OptionBuilder.hasArg(true)
-        .withArgName("/path/to/log/directory").hasArgs(1)
-        .withDescription("the log directory to be processed by Mudrod")
-        .withLongOpt("logDirectory").isRequired().create(LOG_DIR);
+    Option logDirOpt = OptionBuilder.hasArg(true).withArgName("/path/to/log/directory").hasArgs(1).withDescription("the log directory to be processed by Mudrod").withLongOpt("logDirectory")
+        .isRequired().create(LOG_DIR);
 
-    Option esHostOpt = OptionBuilder.hasArg(true).withArgName("host_name")
-        .hasArgs(1).withDescription("elasticsearch cluster unicast host")
-        .withLongOpt("elasticSearchHost").isRequired(false).create(ES_HOST);
+    Option esHostOpt = OptionBuilder.hasArg(true).withArgName("host_name").hasArgs(1).withDescription("elasticsearch cluster unicast host").withLongOpt("elasticSearchHost").isRequired(false)
+        .create(ES_HOST);
 
-    Option esTCPPortOpt = OptionBuilder.hasArg(true).withArgName("port_num")
-        .hasArgs(1).withDescription("elasticsearch transport TCP port")
-        .withLongOpt("elasticSearchTransportTCPPort").isRequired(false)
-        .create(ES_TCP_PORT);
+    Option esTCPPortOpt = OptionBuilder.hasArg(true).withArgName("port_num").hasArgs(1).withDescription("elasticsearch transport TCP port").withLongOpt("elasticSearchTransportTCPPort")
+        .isRequired(false).create(ES_TCP_PORT);
 
-    Option esPortOpt = OptionBuilder.hasArg(true).withArgName("port_num")
-        .hasArgs(1).withDescription("elasticsearch HTTP/REST port")
-        .withLongOpt("elasticSearchHTTPPort").isRequired(false)
+    Option esPortOpt = OptionBuilder.hasArg(true).withArgName("port_num").hasArgs(1).withDescription("elasticsearch HTTP/REST port").withLongOpt("elasticSearchHTTPPort").isRequired(false)
         .create(ES_HTTP_PORT);
 
     // create the options
@@ -421,8 +448,7 @@ public class MudrodEngine {
       me.end();
     } catch (Exception e) {
       HelpFormatter formatter = new HelpFormatter();
-      formatter.printHelp("MudrodEngine: 'logDir' argument is mandatory. "
-          + "User must also provide an ingest method.", options, true);
+      formatter.printHelp("MudrodEngine: 'logDir' argument is mandatory. " + "User must also provide an ingest method.", options, true);
       LOG.error("Error whilst parsing command line.", e);
     }
   }
@@ -433,24 +459,18 @@ public class MudrodEngine {
     me.props.put("userHistoryMatrix", dataDir + "UserHistoryMatrix.csv");
     me.props.put("clickstreamMatrix", dataDir + "ClickstreamMatrix.csv");
     me.props.put("metadataMatrix", dataDir + "MetadataMatrix.csv");
-    me.props.put("clickstreamSVDMatrix_tmp",
-        dataDir + "clickstreamSVDMatrix_tmp.csv");
-    me.props
-        .put("metadataSVDMatrix_tmp", dataDir + "metadataSVDMatrix_tmp.csv");
+    me.props.put("clickstreamSVDMatrix_tmp", dataDir + "clickstreamSVDMatrix_tmp.csv");
+    me.props.put("metadataSVDMatrix_tmp", dataDir + "metadataSVDMatrix_tmp.csv");
     me.props.put("raw_metadataPath", dataDir + "RawMetadata");
 
     me.props.put("jtopia", dataDir + "jtopiaModel");
-    me.props
-        .put("metadata_term_tfidf_matrix", dataDir + "metadata_term_tfidf.csv");
-    me.props
-        .put("metadata_word_tfidf_matrix", dataDir + "metadata_word_tfidf.csv");
-    me.props.put("session_metadata_Matrix",
-        dataDir + "metadata_session_coocurrence_matrix.csv");
+    me.props.put("metadata_term_tfidf_matrix", dataDir + "metadata_term_tfidf.csv");
+    me.props.put("metadata_word_tfidf_matrix", dataDir + "metadata_word_tfidf.csv");
+    me.props.put("session_metadata_Matrix", dataDir + "metadata_session_coocurrence_matrix.csv");
 
     me.props.put("metadataOBCode", dataDir + "MetadataOHCode");
     me.props.put("metadata_topic", dataDir + "metadata_topic");
-    me.props
-        .put("metadata_topic_matrix", dataDir + "metadata_topic_matrix.csv");
+    me.props.put("metadata_topic_matrix", dataDir + "metadata_topic_matrix.csv");
   }
 
   /**

--- a/core/src/main/java/gov/nasa/jpl/mudrod/metadata/pre/ApiHarvester.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/metadata/pre/ApiHarvester.java
@@ -59,8 +59,7 @@ public class ApiHarvester extends DiscoveryStepAbstract {
     es.destroyBulkProcessor();
     endTime = System.currentTimeMillis();
     es.refreshIndex();
-    LOG.info("Metadata harvesting completed. Time elapsed: {}",
-        (endTime - startTime) / 1000);
+    LOG.info("Metadata harvesting completed. Time elapsed: {}", (endTime - startTime) / 1000);
     return null;
   }
 
@@ -69,17 +68,10 @@ public class ApiHarvester extends DiscoveryStepAbstract {
    * invoke this method before import metadata to Elasticsearch.
    */
   public void addMetadataMapping() {
-    String mappingJson = "{\r\n   \"dynamic_templates\": " + "[\r\n      "
-        + "{\r\n         \"strings\": "
-        + "{\r\n            \"match_mapping_type\": \"string\","
-        + "\r\n            \"mapping\": {\r\n               \"type\": \"string\","
-        + "\r\n               \"analyzer\": \"english\"\r\n            }"
-        + "\r\n         }\r\n      }\r\n   ]\r\n}";
-	  
-    es.getClient().admin().indices()
-        .preparePutMapping(props.getProperty("indexName"))
-        .setType(props.getProperty("raw_metadataType")).setSource(mappingJson)
-        .execute().actionGet();
+    String mappingJson = "{\r\n   \"dynamic_templates\": " + "[\r\n      " + "{\r\n         \"strings\": " + "{\r\n            \"match_mapping_type\": \"string\","
+        + "\r\n            \"mapping\": {\r\n               \"type\": \"string\"," + "\r\n               \"analyzer\": \"english\"\r\n            }" + "\r\n         }\r\n      }\r\n   ]\r\n}";
+
+    es.getClient().admin().indices().preparePutMapping(props.getProperty("indexName")).setType(props.getProperty("raw_metadataType")).setSource(mappingJson).execute().actionGet();
   }
 
   /**
@@ -88,8 +80,7 @@ public class ApiHarvester extends DiscoveryStepAbstract {
    * invoking this method.
    */
   private void importToES() {
-    File directory = new File(
-        props.getProperty(MudrodConstants.RAW_METADATA_PATH));
+    File directory = new File(props.getProperty(MudrodConstants.RAW_METADATA_PATH));
     File[] fList = directory.listFiles();
     for (File file : fList) {
       InputStream is;
@@ -108,8 +99,7 @@ public class ApiHarvester extends DiscoveryStepAbstract {
       String jsonTxt = IOUtils.toString(is);
       JsonParser parser = new JsonParser();
       JsonElement item = parser.parse(jsonTxt);
-      IndexRequest ir = new IndexRequest(props.getProperty("indexName"),
-          props.getProperty("raw_metadataType")).source(item.toString());
+      IndexRequest ir = new IndexRequest(props.getProperty("indexName"), props.getProperty("raw_metadataType")).source(item.toString());
       es.getBulkProcessor().add(ir);
     } catch (IOException e) {
       LOG.error("Error indexing metadata record!", e);
@@ -124,22 +114,17 @@ public class ApiHarvester extends DiscoveryStepAbstract {
     int doc_length = 0;
     JsonParser parser = new JsonParser();
     do {
-      String searchAPI =
-          "https://podaac.jpl.nasa.gov/api/dataset?startIndex=" + Integer
-              .toString(startIndex)
-              + "&entries=10&sortField=Dataset-AllTimePopularity&sortOrder=asc&id=&value=&search=";
+      String searchAPI = "https://podaac.jpl.nasa.gov/api/dataset?startIndex=" + Integer.toString(startIndex) + "&entries=10&sortField=Dataset-AllTimePopularity&sortOrder=asc&id=&value=&search=";
       HttpRequest http = new HttpRequest();
       String response = http.getRequest(searchAPI);
 
       JsonElement json = parser.parse(response);
       JsonObject responseObject = json.getAsJsonObject();
-      JsonArray docs = responseObject.getAsJsonObject("response")
-          .getAsJsonArray("docs");
+      JsonArray docs = responseObject.getAsJsonObject("response").getAsJsonArray("docs");
 
       doc_length = docs.size();
 
-      File file = new File(
-          props.getProperty(MudrodConstants.RAW_METADATA_PATH));
+      File file = new File(props.getProperty(MudrodConstants.RAW_METADATA_PATH));
       if (!file.exists()) {
         if (file.mkdir()) {
           LOG.info("Directory is created!");
@@ -150,13 +135,9 @@ public class ApiHarvester extends DiscoveryStepAbstract {
       for (int i = 0; i < doc_length; i++) {
         JsonElement item = docs.get(i);
         int docId = startIndex + i;
-        File itemfile = new File(
-            props.getProperty(MudrodConstants.RAW_METADATA_PATH) + "/" + docId
-                + ".json");
+        File itemfile = new File(props.getProperty(MudrodConstants.RAW_METADATA_PATH) + "/" + docId + ".json");
 
-        try (FileWriter fw = new FileWriter(
-            itemfile.getAbsoluteFile()); BufferedWriter bw = new BufferedWriter(
-            fw);) {
+        try (FileWriter fw = new FileWriter(itemfile.getAbsoluteFile()); BufferedWriter bw = new BufferedWriter(fw);) {
           itemfile.createNewFile();
           bw.write(item.toString());
         } catch (IOException e) {

--- a/core/src/main/java/gov/nasa/jpl/mudrod/metadata/pre/MatrixGenerator.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/metadata/pre/MatrixGenerator.java
@@ -37,8 +37,7 @@ public class MatrixGenerator extends DiscoveryStepAbstract {
    *
    */
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(MatrixGenerator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MatrixGenerator.class);
 
   /**
    * Creates a new instance of MatrixGenerator.
@@ -65,21 +64,16 @@ public class MatrixGenerator extends DiscoveryStepAbstract {
     String metadataMatrixFile = props.getProperty("metadataMatrix");
     try {
       MetadataExtractor extractor = new MetadataExtractor();
-      JavaPairRDD<String, List<String>> metadataTermsRDD = extractor
-          .loadMetadata(this.es, this.spark.sc, props.getProperty("indexName"),
-              props.getProperty("raw_metadataType"));
-      LabeledRowMatrix wordDocMatrix = MatrixUtil
-          .createWordDocMatrix(metadataTermsRDD, spark.sc);
-      MatrixUtil.exportToCSV(wordDocMatrix.rowMatrix, wordDocMatrix.rowkeys,
-          wordDocMatrix.colkeys, metadataMatrixFile);
+      JavaPairRDD<String, List<String>> metadataTermsRDD = extractor.loadMetadata(this.es, this.spark.sc, props.getProperty("indexName"), props.getProperty("raw_metadataType"));
+      LabeledRowMatrix wordDocMatrix = MatrixUtil.createWordDocMatrix(metadataTermsRDD, spark.sc);
+      MatrixUtil.exportToCSV(wordDocMatrix.rowMatrix, wordDocMatrix.rowkeys, wordDocMatrix.colkeys, metadataMatrixFile);
 
     } catch (Exception e) {
       e.printStackTrace();
     }
 
     endTime = System.currentTimeMillis();
-    LOG.info("*****************Metadata matrix ends******************Took {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************Metadata matrix ends******************Took {}s", (endTime - startTime) / 1000);
     return null;
   }
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/metadata/process/MetadataAnalyzer.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/metadata/process/MetadataAnalyzer.java
@@ -30,15 +30,13 @@ import java.util.Properties;
  * Function: Calculate semantic relationship of vocabularies extracted from
  * metadata.
  */
-public class MetadataAnalyzer extends DiscoveryStepAbstract
-    implements Serializable {
+public class MetadataAnalyzer extends DiscoveryStepAbstract implements Serializable {
 
   /**
    *
    */
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(MetadataAnalyzer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataAnalyzer.class);
 
   /**
    * Creates a new instance of MetadataAnalyzer.
@@ -69,18 +67,14 @@ public class MetadataAnalyzer extends DiscoveryStepAbstract
       startTime = System.currentTimeMillis();
 
       SVDAnalyzer analyzer = new SVDAnalyzer(props, es, spark);
-      int svdDimension = Integer
-          .parseInt(props.getProperty("metadataSVDDimension"));
+      int svdDimension = Integer.parseInt(props.getProperty("metadataSVDDimension"));
       String metadataMatrixFile = props.getProperty("metadataMatrix");
       String svdMatrixFileName = props.getProperty("metadataSVDMatrix_tmp");
 
-      analyzer
-          .getSVDMatrix(metadataMatrixFile, svdDimension, svdMatrixFileName);
-      List<LinkageTriple> triples = analyzer
-          .calTermSimfromMatrix(svdMatrixFileName);
+      analyzer.getSVDMatrix(metadataMatrixFile, svdDimension, svdMatrixFileName);
+      List<LinkageTriple> triples = analyzer.calTermSimfromMatrix(svdMatrixFileName);
 
-      analyzer.saveToES(triples, props.getProperty("indexName"),
-          props.getProperty("metadataLinkageType"));
+      analyzer.saveToES(triples, props.getProperty("indexName"), props.getProperty("metadataLinkageType"));
 
     } catch (Exception e) {
       e.printStackTrace();
@@ -88,9 +82,7 @@ public class MetadataAnalyzer extends DiscoveryStepAbstract
 
     endTime = System.currentTimeMillis();
     es.refreshIndex();
-    LOG.info(
-        "*****************Metadata Analyzer ends******************Took {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************Metadata Analyzer ends******************Took {}s", (endTime - startTime) / 1000);
     return null;
   }
 }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/metadata/structure/PODAACMetadata.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/metadata/structure/PODAACMetadata.java
@@ -79,9 +79,7 @@ public class PODAACMetadata implements Serializable {
    * @param keywords  data set keywords
    * @param region    list of regions
    */
-  public PODAACMetadata(String shortname, List<String> longname,
-      List<String> topics, List<String> terms, List<String> variables,
-      List<String> keywords, List<String> region) {
+  public PODAACMetadata(String shortname, List<String> longname, List<String> topics, List<String> terms, List<String> variables, List<String> keywords, List<String> region) {
     this.shortname = shortname;
     this.longnameList = longname;
     this.keywordList = keywords;

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ontology/OntologyFactory.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ontology/OntologyFactory.java
@@ -36,8 +36,7 @@ import java.util.Properties;
  */
 public class OntologyFactory {
 
-  public static final Logger LOG = LoggerFactory
-      .getLogger(OntologyFactory.class);
+  public static final Logger LOG = LoggerFactory.getLogger(OntologyFactory.class);
 
   private Properties props;
 
@@ -63,8 +62,7 @@ public class OntologyFactory {
    */
   public Ontology getOntology() {
 
-    String ontologyImpl = this.props
-        .getProperty(MudrodConstants.ONTOLOGY_IMPL, "Local");
+    String ontologyImpl = this.props.getProperty(MudrodConstants.ONTOLOGY_IMPL, "Local");
 
     LOG.info("Using ontology extension: " + ontologyImpl);
     Ontology ontImpl;

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ontology/pre/AggregateTriples.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ontology/pre/AggregateTriples.java
@@ -40,8 +40,7 @@ import java.util.Properties;
  */
 public class AggregateTriples extends DiscoveryStepAbstract {
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(AggregateTriples.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AggregateTriples.class);
 
   public AggregateTriples(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
@@ -70,8 +69,7 @@ public class AggregateTriples extends DiscoveryStepAbstract {
       e.printStackTrace();
     }
 
-    File[] files = new File(this.props.getProperty("ontologyInputDir"))
-        .listFiles();
+    File[] files = new File(this.props.getProperty("ontologyInputDir")).listFiles();
     for (File file_in : files) {
       String ext = FilenameUtils.getExtension(file_in.getAbsolutePath());
       if ("owl".equals(ext)) {
@@ -122,8 +120,7 @@ public class AggregateTriples extends DiscoveryStepAbstract {
    * Method of going through OWL structure
    */
   public void loopxml() {
-    Iterator<?> processDescendants = rootNode
-        .getDescendants(new ElementFilter());
+    Iterator<?> processDescendants = rootNode.getDescendants(new ElementFilter());
     String text = "";
 
     while (processDescendants.hasNext()) {
@@ -168,54 +165,39 @@ public class AggregateTriples extends DiscoveryStepAbstract {
    * @throws IOException IOException
    */
   public void getAllClass() throws IOException {
-    List<?> classElements = rootNode
-        .getChildren("Class", Namespace.getNamespace("owl", owl_namespace));
+    List<?> classElements = rootNode.getChildren("Class", Namespace.getNamespace("owl", owl_namespace));
 
     for (int i = 0; i < classElements.size(); i++) {
       Element classElement = (Element) classElements.get(i);
-      String className = classElement.getAttributeValue("about",
-          Namespace.getNamespace("rdf", rdf_namespace));
+      String className = classElement.getAttributeValue("about", Namespace.getNamespace("rdf", rdf_namespace));
 
       if (className == null) {
-        className = classElement.getAttributeValue("ID",
-            Namespace.getNamespace("rdf", rdf_namespace));
+        className = classElement.getAttributeValue("ID", Namespace.getNamespace("rdf", rdf_namespace));
       }
 
-      List<?> subclassElements = classElement.getChildren("subClassOf",
-          Namespace.getNamespace("rdfs", rdfs_namespace));
+      List<?> subclassElements = classElement.getChildren("subClassOf", Namespace.getNamespace("rdfs", rdfs_namespace));
       for (int j = 0; j < subclassElements.size(); j++) {
         Element subclassElement = (Element) subclassElements.get(j);
-        String subclassName = subclassElement.getAttributeValue("resource",
-            Namespace.getNamespace("rdf", rdf_namespace));
+        String subclassName = subclassElement.getAttributeValue("resource", Namespace.getNamespace("rdf", rdf_namespace));
         if (subclassName == null) {
-          Element allValuesFromEle = findChild("allValuesFrom",
-              subclassElement);
+          Element allValuesFromEle = findChild("allValuesFrom", subclassElement);
           if (allValuesFromEle != null) {
-            subclassName = allValuesFromEle.getAttributeValue("resource",
-                Namespace.getNamespace("rdf", rdf_namespace));
-            bw.write(
-                cutString(className) + ",SubClassOf," + cutString(subclassName)
-                    + "\n");
+            subclassName = allValuesFromEle.getAttributeValue("resource", Namespace.getNamespace("rdf", rdf_namespace));
+            bw.write(cutString(className) + ",SubClassOf," + cutString(subclassName) + "\n");
           }
         } else {
-          bw.write(
-              cutString(className) + ",SubClassOf," + cutString(subclassName)
-                  + "\n");
+          bw.write(cutString(className) + ",SubClassOf," + cutString(subclassName) + "\n");
         }
 
       }
 
-      List equalClassElements = classElement.getChildren("equivalentClass",
-          Namespace.getNamespace("owl", owl_namespace));
+      List equalClassElements = classElement.getChildren("equivalentClass", Namespace.getNamespace("owl", owl_namespace));
       for (int k = 0; k < equalClassElements.size(); k++) {
         Element equalClassElement = (Element) equalClassElements.get(k);
-        String equalClassElementName = equalClassElement
-            .getAttributeValue("resource",
-                Namespace.getNamespace("rdf", rdf_namespace));
+        String equalClassElementName = equalClassElement.getAttributeValue("resource", Namespace.getNamespace("rdf", rdf_namespace));
 
         if (equalClassElementName != null) {
-          bw.write(cutString(className) + ",equivalentClass," + cutString(
-              equalClassElementName) + "\n");
+          bw.write(cutString(className) + ",equivalentClass," + cutString(equalClassElementName) + "\n");
         }
       }
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ontology/process/LocalOntology.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ontology/process/LocalOntology.java
@@ -60,8 +60,7 @@ public class LocalOntology implements Ontology {
       ontology = this;
     }
     if (ontologyModel == null)
-      ontologyModel = ModelFactory
-          .createOntologyModel(OntModelSpec.OWL_MEM, null);
+      ontologyModel = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, null);
   }
 
   /**
@@ -83,8 +82,7 @@ public class LocalOntology implements Ontology {
    */
   @Override
   public void load() {
-    File ontDir = new File(
-        LocalOntology.class.getClassLoader().getResource("ontology").getFile());
+    File ontDir = new File(LocalOntology.class.getClassLoader().getResource("ontology").getFile());
 
     //Fail if the input is not a directory.
     if (ontDir.isDirectory()) {
@@ -156,8 +154,7 @@ public class LocalOntology implements Ontology {
 
       if (resource instanceof OntClass) {
         //get subclasses
-        for (Iterator i = ((OntClass) resource).listSubClasses(); i
-            .hasNext(); ) {
+        for (Iterator i = ((OntClass) resource).listSubClasses(); i.hasNext(); ) {
           OntResource subclass = (OntResource) i.next();
           for (Iterator j = subclass.listLabels(null); j.hasNext(); ) {
             Literal l = (Literal) j.next();
@@ -165,8 +162,7 @@ public class LocalOntology implements Ontology {
           }
         }
         //get individuals
-        for (Iterator i = ((OntClass) resource).listInstances(); i
-            .hasNext(); ) {
+        for (Iterator i = ((OntClass) resource).listInstances(); i.hasNext(); ) {
           OntResource subclass = (OntResource) i.next();
           for (Iterator j = subclass.listLabels(null); j.hasNext(); ) {
             Literal l = (Literal) j.next();
@@ -221,8 +217,7 @@ public class LocalOntology implements Ontology {
         }
       } else if (resource instanceof OntClass) {
         //list equivalent classes
-        for (Iterator i = ((OntClass) resource).listEquivalentClasses(); i
-            .hasNext(); ) {
+        for (Iterator i = ((OntClass) resource).listEquivalentClasses(); i.hasNext(); ) {
           OntClass equivClass = (OntClass) i.next();
           //add labels
           for (Iterator j = equivClass.listLabels(null); j.hasNext(); ) {
@@ -246,16 +241,14 @@ public class LocalOntology implements Ontology {
   }
 
   public static Map<OntResource, String> retrieve(String label) {
-    @SuppressWarnings("unchecked") Map<OntResource, String> m = (Map<OntResource, String>) searchTerms
-        .get(label.toLowerCase());
+    @SuppressWarnings("unchecked") Map<OntResource, String> m = (Map<OntResource, String>) searchTerms.get(label.toLowerCase());
     if (m == null) {
       m = new HashMap<>();
     }
     return m;
   }
 
-  protected static void renderHierarchy(PrintStream out, OntClass cls,
-      List occurs, int depth) {
+  protected static void renderHierarchy(PrintStream out, OntClass cls, List occurs, int depth) {
     renderClassDescription(out, cls, depth);
     out.println();
 
@@ -282,8 +275,7 @@ public class LocalOntology implements Ontology {
     }
   }
 
-  public static void renderClassDescription(PrintStream out, OntClass c,
-      int depth) {
+  public static void renderClassDescription(PrintStream out, OntClass c, int depth) {
     indent(out, depth);
 
     if (c.isRestriction()) {
@@ -318,13 +310,11 @@ public class LocalOntology implements Ontology {
     renderURI(out, r.getModel(), r.getOnProperty().getURI());
   }
 
-  protected static void renderURI(PrintStream out, PrefixMapping prefixes,
-      String uri) {
+  protected static void renderURI(PrintStream out, PrefixMapping prefixes, String uri) {
     out.print(prefixes.expandPrefix(uri));
   }
 
-  protected static void renderAnonymous(PrintStream out, Resource anon,
-      String name) {
+  protected static void renderAnonymous(PrintStream out, Resource anon, String name) {
     String anonID = (String) mAnonIDs.get(anon.getId());
     if (anonID == null) {
       anonID = "a-" + mAnonCount++;
@@ -348,9 +338,7 @@ public class LocalOntology implements Ontology {
     // boolean options
     Option helpOpt = new Option("h", "help", false, "show this help message");
     // argument options
-    Option ontDirOpt = OptionBuilder.hasArg(true).withArgName(ONT_DIR)
-        .withDescription("A directory containing .owl files.").isRequired(false)
-        .create();
+    Option ontDirOpt = OptionBuilder.hasArg(true).withArgName(ONT_DIR).withDescription("A directory containing .owl files.").isRequired(false).create();
 
     // create the options
     Options options = new Options();
@@ -365,8 +353,7 @@ public class LocalOntology implements Ontology {
       if (line.hasOption(ONT_DIR)) {
         ontDir = line.getOptionValue(ONT_DIR).replace("\\", "/");
       } else {
-        ontDir = LocalOntology.class.getClassLoader().getResource("ontology")
-            .getFile();
+        ontDir = LocalOntology.class.getClassLoader().getResource("ontology").getFile();
       }
       if (!ontDir.endsWith("/")) {
         ontDir += "/";
@@ -374,9 +361,7 @@ public class LocalOntology implements Ontology {
     } catch (Exception e) {
       LOG.error("Error whilst processing main method of LocalOntology.", e);
       HelpFormatter formatter = new HelpFormatter();
-      formatter
-          .printHelp("LocalOntology: 'ontDir' argument is mandatory. ", options,
-              true);
+      formatter.printHelp("LocalOntology: 'ontDir' argument is mandatory. ", options, true);
       return;
     }
     File fileDir = new File(ontDir);
@@ -396,15 +381,13 @@ public class LocalOntology implements Ontology {
 
       String[] terms = new String[] { "Glacier ice" };
       //Demonstrate that we can do basic ontology heirarchy navigation and log output.
-      for (Iterator<OntClass> i = getParser().rootClasses(getModel()); i
-          .hasNext(); ) {
+      for (Iterator<OntClass> i = getParser().rootClasses(getModel()); i.hasNext(); ) {
 
         //print Ontology Class Hierarchy
         OntClass c = i.next();
         renderHierarchy(System.out, c, new LinkedList<>(), 0);
 
-        for (Iterator<OntClass> subClass = c.listSubClasses(true); subClass
-            .hasNext(); ) {
+        for (Iterator<OntClass> subClass = c.listSubClasses(true); subClass.hasNext(); ) {
           OntClass sub = subClass.next();
           //This means that the search term is present as an OntClass
           if (terms[0].equalsIgnoreCase(sub.getLabel(null))) {

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ontology/process/OwlParser.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ontology/process/OwlParser.java
@@ -133,8 +133,7 @@ public class OwlParser implements OntologyParser {
 
     String labelString = idString;
     while (m.find()) {
-      labelString = labelString
-          .replaceAll(m.group(1) + m.group(2), m.group(1) + " " + m.group(2));
+      labelString = labelString.replaceAll(m.group(1) + m.group(2), m.group(1) + " " + m.group(2));
     }
     return labelString;
   }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/pre/ImportMetadata.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/pre/ImportMetadata.java
@@ -51,9 +51,7 @@ public class ImportMetadata extends DiscoveryStepAbstract {
     importToES();
     endTime = System.currentTimeMillis();
     es.refreshIndex();
-    LOG.info(
-        "*****************Metadata harvesting ends******************Took {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************Metadata harvesting ends******************Took {}s", (endTime - startTime) / 1000);
     return null;
   }
 
@@ -62,17 +60,10 @@ public class ImportMetadata extends DiscoveryStepAbstract {
    * invoke this method before import metadata to Elasticsearch.
    */
   public void addMetadataMapping() {
-    String mappingJson = "{\r\n   \"dynamic_templates\": " + "[\r\n      "
-        + "{\r\n         \"strings\": "
-        + "{\r\n            \"match_mapping_type\": \"string\","
-        + "\r\n            \"mapping\": {\r\n               \"type\": \"string\","
-        + "\r\n               \"analyzer\": \"csv\"\r\n            }"
-        + "\r\n         }\r\n      }\r\n   ]\r\n}";
+    String mappingJson = "{\r\n   \"dynamic_templates\": " + "[\r\n      " + "{\r\n         \"strings\": " + "{\r\n            \"match_mapping_type\": \"string\","
+        + "\r\n            \"mapping\": {\r\n               \"type\": \"string\"," + "\r\n               \"analyzer\": \"csv\"\r\n            }" + "\r\n         }\r\n      }\r\n   ]\r\n}";
 
-    es.getClient().admin().indices()
-        .preparePutMapping(props.getProperty("indexName"))
-        .setType(props.getProperty("recom_metadataType")).setSource(mappingJson)
-        .execute().actionGet();
+    es.getClient().admin().indices().preparePutMapping(props.getProperty("indexName")).setType(props.getProperty("recom_metadataType")).setSource(mappingJson).execute().actionGet();
 
   }
 
@@ -82,8 +73,7 @@ public class ImportMetadata extends DiscoveryStepAbstract {
    * invoking this method.
    */
   private void importToES() {
-    es.deleteType(props.getProperty("indexName"),
-        props.getProperty("recom_metadataType"));
+    es.deleteType(props.getProperty("indexName"), props.getProperty("recom_metadataType"));
 
     es.createBulkProcessor();
     File directory = new File(props.getProperty("raw_metadataPath"));
@@ -96,8 +86,7 @@ public class ImportMetadata extends DiscoveryStepAbstract {
           String jsonTxt = IOUtils.toString(is);
           JsonParser parser = new JsonParser();
           JsonElement item = parser.parse(jsonTxt);
-          IndexRequest ir = new IndexRequest(props.getProperty("indexName"),
-              props.getProperty("recom_metadataType")).source(item.toString());
+          IndexRequest ir = new IndexRequest(props.getProperty("indexName"), props.getProperty("recom_metadataType")).source(item.toString());
 
           // preprocessdata
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/pre/MetadataTFIDFGenerator.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/pre/MetadataTFIDFGenerator.java
@@ -28,8 +28,7 @@ import java.util.Properties;
 public class MetadataTFIDFGenerator extends DiscoveryStepAbstract {
 
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(MetadataTFIDFGenerator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataTFIDFGenerator.class);
 
   /**
    * Creates a new instance of MatrixGenerator.
@@ -38,16 +37,14 @@ public class MetadataTFIDFGenerator extends DiscoveryStepAbstract {
    * @param es    the Elasticsearch drive
    * @param spark the spark drive
    */
-  public MetadataTFIDFGenerator(Properties props, ESDriver es,
-      SparkDriver spark) {
+  public MetadataTFIDFGenerator(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
   }
 
   @Override
   public Object execute() {
 
-    LOG.info(
-        "*****************Dataset TF_IDF Matrix Generator starts******************");
+    LOG.info("*****************Dataset TF_IDF Matrix Generator starts******************");
 
     startTime = System.currentTimeMillis();
     try {
@@ -58,9 +55,7 @@ public class MetadataTFIDFGenerator extends DiscoveryStepAbstract {
     }
     endTime = System.currentTimeMillis();
 
-    LOG.info(
-        "*****************Dataset TF_IDF Matrix Generator ends******************Took {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************Dataset TF_IDF Matrix Generator ends******************Took {}s", (endTime - startTime) / 1000);
 
     return null;
   }
@@ -78,14 +73,11 @@ public class MetadataTFIDFGenerator extends DiscoveryStepAbstract {
 
     JavaPairRDD<String, String> metadataContents = opt.loadAll(es, spark);
 
-    JavaPairRDD<String, List<String>> metadataWords = opt
-        .tokenizeData(metadataContents, " ");
+    JavaPairRDD<String, List<String>> metadataWords = opt.tokenizeData(metadataContents, " ");
 
     LabeledRowMatrix wordtfidfMatrix = opt.TFIDFTokens(metadataWords, spark);
 
-    MatrixUtil.exportToCSV(wordtfidfMatrix.rowMatrix, wordtfidfMatrix.rowkeys,
-        wordtfidfMatrix.colkeys,
-        props.getProperty("metadata_word_tfidf_matrix"));
+    MatrixUtil.exportToCSV(wordtfidfMatrix.rowMatrix, wordtfidfMatrix.rowkeys, wordtfidfMatrix.colkeys, props.getProperty("metadata_word_tfidf_matrix"));
 
     return wordtfidfMatrix;
   }
@@ -99,17 +91,13 @@ public class MetadataTFIDFGenerator extends DiscoveryStepAbstract {
     variables.add("DatasetParameter-Variable");
     variables.add("Dataset-ExtractTerm");
 
-    JavaPairRDD<String, String> metadataContents = opt
-        .loadAll(es, spark, variables);
+    JavaPairRDD<String, String> metadataContents = opt.loadAll(es, spark, variables);
 
-    JavaPairRDD<String, List<String>> metadataTokens = opt
-        .tokenizeData(metadataContents, ",");
+    JavaPairRDD<String, List<String>> metadataTokens = opt.tokenizeData(metadataContents, ",");
 
     LabeledRowMatrix tokentfidfMatrix = opt.TFIDFTokens(metadataTokens, spark);
 
-    MatrixUtil.exportToCSV(tokentfidfMatrix.rowMatrix, tokentfidfMatrix.rowkeys,
-        tokentfidfMatrix.colkeys,
-        props.getProperty("metadata_term_tfidf_matrix"));
+    MatrixUtil.exportToCSV(tokentfidfMatrix.rowMatrix, tokentfidfMatrix.rowkeys, tokentfidfMatrix.colkeys, props.getProperty("metadata_term_tfidf_matrix"));
 
     return tokentfidfMatrix;
   }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/pre/NormalizeVariables.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/pre/NormalizeVariables.java
@@ -22,8 +22,7 @@ public class NormalizeVariables extends DiscoveryStepAbstract {
    *
    */
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(NormalizeVariables.class);
+  private static final Logger LOG = LoggerFactory.getLogger(NormalizeVariables.class);
   // index name
   private String indexName;
   // type name of metadata in ES
@@ -44,16 +43,13 @@ public class NormalizeVariables extends DiscoveryStepAbstract {
 
   @Override
   public Object execute() {
-    LOG.info(
-        "*****************processing metadata variables starts******************");
+    LOG.info("*****************processing metadata variables starts******************");
     startTime = System.currentTimeMillis();
 
     normalizeMetadataVariables(es);
 
     endTime = System.currentTimeMillis();
-    LOG.info(
-        "*****************processing metadata variables ends******************Took {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************processing metadata variables ends******************Took {}s", (endTime - startTime) / 1000);
 
     return null;
   }
@@ -67,9 +63,7 @@ public class NormalizeVariables extends DiscoveryStepAbstract {
 
     es.createBulkProcessor();
 
-    SearchResponse scrollResp = es.getClient().prepareSearch(indexName)
-        .setTypes(metadataType).setScroll(new TimeValue(60000))
-        .setQuery(QueryBuilders.matchAllQuery()).setSize(100).execute()
+    SearchResponse scrollResp = es.getClient().prepareSearch(indexName).setTypes(metadataType).setScroll(new TimeValue(60000)).setQuery(QueryBuilders.matchAllQuery()).setSize(100).execute()
         .actionGet();
     while (true) {
       for (SearchHit hit : scrollResp.getHits().getHits()) {
@@ -80,14 +74,11 @@ public class NormalizeVariables extends DiscoveryStepAbstract {
         this.normalizeTemporalVariables(metadata, updatedValues);
         this.normalizeOtherVariables(metadata, updatedValues);
 
-        UpdateRequest ur = es
-            .generateUpdateRequest(indexName, metadataType, hit.getId(),
-                updatedValues);
+        UpdateRequest ur = es.generateUpdateRequest(indexName, metadataType, hit.getId(), updatedValues);
         es.getBulkProcessor().add(ur);
       }
 
-      scrollResp = es.getClient().prepareSearchScroll(scrollResp.getScrollId())
-          .setScroll(new TimeValue(600000)).execute().actionGet();
+      scrollResp = es.getClient().prepareSearchScroll(scrollResp.getScrollId()).setScroll(new TimeValue(600000)).execute().actionGet();
       if (scrollResp.getHits().getHits().length == 0) {
         break;
       }
@@ -96,8 +87,7 @@ public class NormalizeVariables extends DiscoveryStepAbstract {
     es.destroyBulkProcessor();
   }
 
-  private void normalizeOtherVariables(Map<String, Object> metadata,
-      Map<String, Object> updatedValues) {
+  private void normalizeOtherVariables(Map<String, Object> metadata, Map<String, Object> updatedValues) {
     String shortname = (String) metadata.get("Dataset-ShortName");
     double versionNUm = getVersionNum(shortname);
     updatedValues.put("Dataset-Derivative-VersionNum", versionNUm);
@@ -125,8 +115,7 @@ public class NormalizeVariables extends DiscoveryStepAbstract {
     return versionNum;
   }
 
-  private void normalizeSpatialVariables(Map<String, Object> metadata,
-      Map<String, Object> updatedValues) {
+  private void normalizeSpatialVariables(Map<String, Object> metadata, Map<String, Object> updatedValues) {
 
     // get spatial resolution
     Double spatialR;
@@ -144,11 +133,9 @@ public class NormalizeVariables extends DiscoveryStepAbstract {
 
     // Transform Longitude and calculate coverage area
     double top = parseDouble((String) metadata.get("DatasetCoverage-NorthLat"));
-    double bottom = parseDouble(
-        (String) metadata.get("DatasetCoverage-SouthLat"));
+    double bottom = parseDouble((String) metadata.get("DatasetCoverage-SouthLat"));
     double left = parseDouble((String) metadata.get("DatasetCoverage-WestLon"));
-    double right = parseDouble(
-        (String) metadata.get("DatasetCoverage-EastLon"));
+    double right = parseDouble((String) metadata.get("DatasetCoverage-EastLon"));
 
     if (left > 180) {
       left = left - 360;
@@ -177,16 +164,14 @@ public class NormalizeVariables extends DiscoveryStepAbstract {
     updatedValues.put("Dataset-Derivative-ProcessingLevel", dProLevel);
   }
 
-  private void normalizeTemporalVariables(Map<String, Object> metadata,
-      Map<String, Object> updatedValues) {
+  private void normalizeTemporalVariables(Map<String, Object> metadata, Map<String, Object> updatedValues) {
 
     String trStr = (String) metadata.get("Dataset-TemporalResolution");
     if ("".equals(trStr)) {
       trStr = (String) metadata.get("Dataset-TemporalRepeat");
     }
 
-    updatedValues
-        .put("Dataset-Derivative-TemporalResolution", covertTimeUnit(trStr));
+    updatedValues.put("Dataset-Derivative-TemporalResolution", covertTimeUnit(trStr));
   }
 
   private Double covertTimeUnit(String str) {

--- a/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/process/AbstractBasedSimilarity.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/process/AbstractBasedSimilarity.java
@@ -24,8 +24,7 @@ import java.util.Properties;
  */
 public class AbstractBasedSimilarity extends DiscoveryStepAbstract {
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(AbstractBasedSimilarity.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractBasedSimilarity.class);
 
   /**
    * Creates a new instance of TopicBasedCF.
@@ -34,16 +33,14 @@ public class AbstractBasedSimilarity extends DiscoveryStepAbstract {
    * @param es    the Elasticsearch client
    * @param spark the spark drive
    */
-  public AbstractBasedSimilarity(Properties props, ESDriver es,
-      SparkDriver spark) {
+  public AbstractBasedSimilarity(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
   }
 
   @Override
   public Object execute() {
 
-    LOG.info(
-        "*****************abstract similarity calculation starts******************");
+    LOG.info("*****************abstract similarity calculation starts******************");
     startTime = System.currentTimeMillis();
 
     try {
@@ -56,21 +53,16 @@ public class AbstractBasedSimilarity extends DiscoveryStepAbstract {
 
       // for comparison
       SVDAnalyzer svd = new SVDAnalyzer(props, es, spark);
-      svd.getSVDMatrix(props.getProperty("metadata_word_tfidf_matrix"), 150,
-          props.getProperty("metadata_word_tfidf_matrix"));
-      List<LinkageTriple> tripleList = svd.calTermSimfromMatrix(
-          props.getProperty("metadata_word_tfidf_matrix"));
-      svd.saveToES(tripleList, props.getProperty("indexName"),
-          props.getProperty("metadataWordTFIDFSimType"), true, true);
+      svd.getSVDMatrix(props.getProperty("metadata_word_tfidf_matrix"), 150, props.getProperty("metadata_word_tfidf_matrix"));
+      List<LinkageTriple> tripleList = svd.calTermSimfromMatrix(props.getProperty("metadata_word_tfidf_matrix"));
+      svd.saveToES(tripleList, props.getProperty("indexName"), props.getProperty("metadataWordTFIDFSimType"), true, true);
 
     } catch (Exception e) {
       e.printStackTrace();
     }
 
     endTime = System.currentTimeMillis();
-    LOG.info(
-        "*****************abstract similarity calculation ends******************Took {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************abstract similarity calculation ends******************Took {}s", (endTime - startTime) / 1000);
 
     return null;
   }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/process/sessionBasedCF.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/process/sessionBasedCF.java
@@ -25,8 +25,7 @@ import java.util.Properties;
  */
 public class sessionBasedCF extends DiscoveryStepAbstract {
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(sessionBasedCF.class);
+  private static final Logger LOG = LoggerFactory.getLogger(sessionBasedCF.class);
 
   /**
    * Creates a new instance of sessionBasedCF.
@@ -41,27 +40,21 @@ public class sessionBasedCF extends DiscoveryStepAbstract {
 
   @Override
   public Object execute() {
-    LOG.info(
-        "*****************Session based metadata similarity starts******************");
+    LOG.info("*****************Session based metadata similarity starts******************");
     startTime = System.currentTimeMillis();
 
     try {
       String session_metadatFile = props.getProperty("session_metadata_Matrix");
       SemanticAnalyzer analyzer = new SemanticAnalyzer(props, es, spark);
-      List<LinkageTriple> triples = analyzer
-          .calTermSimfromMatrix(session_metadatFile, SimilarityUtil.SIM_PEARSON,
-              1);
-      analyzer.saveToES(triples, props.getProperty("indexName"),
-          props.getProperty("metadataSessionBasedSimType"), true, false);
+      List<LinkageTriple> triples = analyzer.calTermSimfromMatrix(session_metadatFile, SimilarityUtil.SIM_PEARSON, 1);
+      analyzer.saveToES(triples, props.getProperty("indexName"), props.getProperty("metadataSessionBasedSimType"), true, false);
 
     } catch (Exception e) {
       e.printStackTrace();
     }
 
     endTime = System.currentTimeMillis();
-    LOG.info(
-        "*****************Session based metadata similarity ends******************Took {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("*****************Session based metadata similarity ends******************Took {}s", (endTime - startTime) / 1000);
 
     return null;
   }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/structure/HybridRecommendation.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/structure/HybridRecommendation.java
@@ -62,8 +62,7 @@ public class HybridRecommendation extends DiscoveryStepAbstract {
     }
   }
 
-  public HybridRecommendation(Properties props, ESDriver es,
-      SparkDriver spark) {
+  public HybridRecommendation(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
   }
 
@@ -88,16 +87,13 @@ public class HybridRecommendation extends DiscoveryStepAbstract {
     JsonObject resultJson = new JsonObject();
 
     String type = props.getProperty("metadataCodeSimType");
-    Map<String, Double> sortedVariableSimMap = getRelatedData(type, input,
-        num + 10);
+    Map<String, Double> sortedVariableSimMap = getRelatedData(type, input, num + 10);
 
     type = props.getProperty("metadataWordTFIDFSimType");
-    Map<String, Double> sortedAbstractSimMap = getRelatedData(type, input,
-        num + 10);
+    Map<String, Double> sortedAbstractSimMap = getRelatedData(type, input, num + 10);
 
     type = props.getProperty("metadataSessionBasedSimType");
-    Map<String, Double> sortedSessionSimMap = getRelatedData(type, input,
-        num + 10);
+    Map<String, Double> sortedSessionSimMap = getRelatedData(type, input, num + 10);
 
     JsonElement variableSimJson = mapToJson(sortedVariableSimMap, num);
     resultJson.add("variableSim", variableSimJson);
@@ -114,8 +110,7 @@ public class HybridRecommendation extends DiscoveryStepAbstract {
 
     for (String name : sortedVariableSimMap.keySet()) {
       if (hybirdSimMap.get(name) != null) {
-        double sim =
-            hybirdSimMap.get(name) + sortedVariableSimMap.get(name) /** 0.3 */;
+        double sim = hybirdSimMap.get(name) + sortedVariableSimMap.get(name) /** 0.3 */;
         hybirdSimMap.put(name, Double.parseDouble(df.format(sim)));
       } else {
         double sim = sortedVariableSimMap.get(name);
@@ -125,8 +120,7 @@ public class HybridRecommendation extends DiscoveryStepAbstract {
 
     for (String name : sortedSessionSimMap.keySet()) {
       if (hybirdSimMap.get(name) != null) {
-        double sim =
-            hybirdSimMap.get(name) + sortedSessionSimMap.get(name) /** 0.1 */;
+        double sim = hybirdSimMap.get(name) + sortedSessionSimMap.get(name) /** 0.1 */;
         hybirdSimMap.put(name, Double.parseDouble(df.format(sim)));
       } else {
         double sim = sortedSessionSimMap.get(name);
@@ -182,8 +176,7 @@ public class HybridRecommendation extends DiscoveryStepAbstract {
    * @return recommended dataset map, key is dataset name, value is similarity
    * value
    */
-  public Map<String, Double> getRelatedData(String type, String input,
-      int num) {
+  public Map<String, Double> getRelatedData(String type, String input, int num) {
     termList = new ArrayList<>();
     Map<String, Double> termsMap = new HashMap<>();
     Map<String, Double> sortedMap = new HashMap<>();
@@ -210,13 +203,10 @@ public class HybridRecommendation extends DiscoveryStepAbstract {
    * @param num   the number of recommended dataset
    * @return recommended dataset list
    */
-  public List<LinkedTerm> getRelatedDataFromES(String type, String input,
-      int num) {
+  public List<LinkedTerm> getRelatedDataFromES(String type, String input, int num) {
 
-    SearchRequestBuilder builder = es.getClient()
-        .prepareSearch(props.getProperty(INDEX_NAME)).setTypes(type)
-        .setQuery(QueryBuilders.termQuery("concept_A", input))
-        .addSort(WEIGHT, SortOrder.DESC).setSize(num);
+    SearchRequestBuilder builder = es.getClient().prepareSearch(props.getProperty(INDEX_NAME)).setTypes(type).setQuery(QueryBuilders.termQuery("concept_A", input)).addSort(WEIGHT, SortOrder.DESC)
+        .setSize(num);
 
     SearchResponse usrhis = builder.execute().actionGet();
 
@@ -225,8 +215,7 @@ public class HybridRecommendation extends DiscoveryStepAbstract {
       String conceptB = (String) result.get("concept_B");
 
       if (!conceptB.equals(input)) {
-        LinkedTerm lTerm = new LinkedTerm(conceptB, (double) result.get(WEIGHT),
-            type);
+        LinkedTerm lTerm = new LinkedTerm(conceptB, (double) result.get(WEIGHT), type);
         termList.add(lTerm);
       }
     }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/structure/RecomData.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/structure/RecomData.java
@@ -114,8 +114,7 @@ public class RecomData extends DiscoveryStepAbstract {
     return nodesElement;
   }
 
-  public Map<String, Double> getRelatedData(String type, String input,
-      int num) {
+  public Map<String, Double> getRelatedData(String type, String input, int num) {
     termList = new ArrayList<>();
     Map<String, Double> termsMap = new HashMap<>();
     Map<String, Double> sortedMap = new HashMap<>();
@@ -134,12 +133,9 @@ public class RecomData extends DiscoveryStepAbstract {
     return sortedMap;
   }
 
-  public List<LinkedTerm> getRelatedDataFromES(String type, String input,
-      int num) {
-    SearchRequestBuilder builder = es.getClient()
-        .prepareSearch(props.getProperty(INDEX_NAME)).setTypes(type)
-        .setQuery(QueryBuilders.termQuery("concept_A", input))
-        .addSort(WEIGHT, SortOrder.DESC).setSize(num);
+  public List<LinkedTerm> getRelatedDataFromES(String type, String input, int num) {
+    SearchRequestBuilder builder = es.getClient().prepareSearch(props.getProperty(INDEX_NAME)).setTypes(type).setQuery(QueryBuilders.termQuery("concept_A", input)).addSort(WEIGHT, SortOrder.DESC)
+        .setSize(num);
 
     SearchResponse usrhis = builder.execute().actionGet();
 
@@ -148,8 +144,7 @@ public class RecomData extends DiscoveryStepAbstract {
       String conceptB = (String) result.get("concept_B");
 
       if (!conceptB.equals(input)) {
-        LinkedTerm lTerm = new LinkedTerm(conceptB, (double) result.get(WEIGHT),
-            type);
+        LinkedTerm lTerm = new LinkedTerm(conceptB, (double) result.get(WEIGHT), type);
         termList.add(lTerm);
       }
     }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/semantics/SVDAnalyzer.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/semantics/SVDAnalyzer.java
@@ -49,15 +49,12 @@ public class SVDAnalyzer extends SemanticAnalyzer {
    * @param svdDimention      Dimension of SVD matrix
    * @param svdMatrixFileName CSV file name of SVD matrix
    */
-  public void getSVDMatrix(String csvFileName, int svdDimention,
-      String svdMatrixFileName) {
+  public void getSVDMatrix(String csvFileName, int svdDimention, String svdMatrixFileName) {
 
-    JavaPairRDD<String, Vector> importRDD = MatrixUtil
-        .loadVectorFromCSV(spark, csvFileName, 1);
+    JavaPairRDD<String, Vector> importRDD = MatrixUtil.loadVectorFromCSV(spark, csvFileName, 1);
     JavaRDD<Vector> vectorRDD = importRDD.values();
     RowMatrix wordDocMatrix = new RowMatrix(vectorRDD.rdd());
-    RowMatrix tfidfMatrix = MatrixUtil
-        .createTFIDFMatrix(wordDocMatrix, spark.sc);
+    RowMatrix tfidfMatrix = MatrixUtil.createTFIDFMatrix(wordDocMatrix, spark.sc);
     RowMatrix svdMatrix = MatrixUtil.buildSVDMatrix(tfidfMatrix, svdDimention);
 
     List<String> rowKeys = importRDD.keys().collect();

--- a/core/src/main/java/gov/nasa/jpl/mudrod/semantics/SemanticAnalyzer.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/semantics/SemanticAnalyzer.java
@@ -60,30 +60,23 @@ public class SemanticAnalyzer extends MudrodAbstract {
     return this.calTermSimfromMatrix(csvFileName, 1);
   }
 
-  public List<LinkageTriple> calTermSimfromMatrix(String csvFileName,
-      int skipRow) {
+  public List<LinkageTriple> calTermSimfromMatrix(String csvFileName, int skipRow) {
 
-    JavaPairRDD<String, Vector> importRDD = MatrixUtil
-        .loadVectorFromCSV(spark, csvFileName, skipRow);
-    CoordinateMatrix simMatrix = SimilarityUtil
-        .calculateSimilarityFromVector(importRDD.values());
+    JavaPairRDD<String, Vector> importRDD = MatrixUtil.loadVectorFromCSV(spark, csvFileName, skipRow);
+    CoordinateMatrix simMatrix = SimilarityUtil.calculateSimilarityFromVector(importRDD.values());
     JavaRDD<String> rowKeyRDD = importRDD.keys();
     return SimilarityUtil.matrixToTriples(rowKeyRDD, simMatrix);
   }
 
-  public List<LinkageTriple> calTermSimfromMatrix(String csvFileName,
-      int simType, int skipRow) {
+  public List<LinkageTriple> calTermSimfromMatrix(String csvFileName, int simType, int skipRow) {
 
-    JavaPairRDD<String, Vector> importRDD = MatrixUtil
-        .loadVectorFromCSV(spark, csvFileName, skipRow);
-    JavaRDD<LinkageTriple> triples = SimilarityUtil
-        .calculateSimilarityFromVector(importRDD, simType);
+    JavaPairRDD<String, Vector> importRDD = MatrixUtil.loadVectorFromCSV(spark, csvFileName, skipRow);
+    JavaRDD<LinkageTriple> triples = SimilarityUtil.calculateSimilarityFromVector(importRDD, simType);
 
     return triples.collect();
   }
 
-  public void saveToES(List<LinkageTriple> tripleList, String index,
-      String type) {
+  public void saveToES(List<LinkageTriple> tripleList, String index, String type) {
     try {
       LinkageTriple.insertTriples(es, tripleList, index, type);
     } catch (IOException e) {
@@ -100,11 +93,9 @@ public class SemanticAnalyzer extends MudrodAbstract {
    * @param bTriple    bTriple
    * @param bSymmetry  bSymmetry
    */
-  public void saveToES(List<LinkageTriple> tripleList, String index,
-      String type, boolean bTriple, boolean bSymmetry) {
+  public void saveToES(List<LinkageTriple> tripleList, String index, String type, boolean bTriple, boolean bSymmetry) {
     try {
-      LinkageTriple
-          .insertTriples(es, tripleList, index, type, bTriple, bSymmetry);
+      LinkageTriple.insertTriples(es, tripleList, index, type, bTriple, bSymmetry);
     } catch (IOException e) {
       e.printStackTrace();
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ClickstreamImporter.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ClickstreamImporter.java
@@ -48,19 +48,12 @@ public class ClickstreamImporter extends MudrodAbstract {
   public void addClickStreamMapping() {
     XContentBuilder Mapping;
     try {
-      Mapping = jsonBuilder().startObject()
-          .startObject(props.getProperty("clickstreamMatrixType"))
-          .startObject("properties").startObject("query")
-          .field("type", "string").field("index", "not_analyzed").endObject()
-          .startObject("dataID").field("type", "string")
-          .field("index", "not_analyzed").endObject()
+      Mapping = jsonBuilder().startObject().startObject(props.getProperty("clickstreamMatrixType")).startObject("properties").startObject("query").field("type", "string")
+          .field("index", "not_analyzed").endObject().startObject("dataID").field("type", "string").field("index", "not_analyzed").endObject()
 
           .endObject().endObject().endObject();
 
-      es.getClient().admin().indices()
-          .preparePutMapping(props.getProperty("indexName"))
-          .setType(props.getProperty("clickstreamMatrixType"))
-          .setSource(Mapping).execute().actionGet();
+      es.getClient().admin().indices().preparePutMapping(props.getProperty("indexName")).setType(props.getProperty("clickstreamMatrixType")).setSource(Mapping).execute().actionGet();
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -70,16 +63,14 @@ public class ClickstreamImporter extends MudrodAbstract {
    * Method to import click stream CSV into Elasticsearch
    */
   public void importfromCSVtoES() {
-    es.deleteType(props.getProperty("indexName"),
-        props.getProperty("clickstreamMatrixType"));
+    es.deleteType(props.getProperty("indexName"), props.getProperty("clickstreamMatrixType"));
     es.createBulkProcessor();
 
     BufferedReader br = null;
     String cvsSplitBy = ",";
 
     try {
-      br = new BufferedReader(
-          new FileReader(props.getProperty("clickstreamMatrix")));
+      br = new BufferedReader(new FileReader(props.getProperty("clickstreamMatrix")));
       String line = br.readLine();
       // first item needs to be skipped
       String dataList[] = line.split(cvsSplitBy);
@@ -87,11 +78,8 @@ public class ClickstreamImporter extends MudrodAbstract {
         String[] clicks = line.split(cvsSplitBy);
         for (int i = 1; i < clicks.length; i++) {
           if (!clicks[i].equals("0.0")) {
-            IndexRequest ir = new IndexRequest(props.getProperty("indexName"),
-                props.getProperty("clickstreamMatrixType")).source(
-                jsonBuilder().startObject().field("query", clicks[0])
-                    .field("dataID", dataList[i]).field("clicks", clicks[i])
-                    .endObject());
+            IndexRequest ir = new IndexRequest(props.getProperty("indexName"), props.getProperty("clickstreamMatrixType"))
+                .source(jsonBuilder().startObject().field("query", clicks[0]).field("dataID", dataList[i]).field("clicks", clicks[i]).endObject());
             es.getBulkProcessor().add(ir);
           }
         }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/Dispatcher.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/Dispatcher.java
@@ -88,25 +88,17 @@ public class Dispatcher extends MudrodAbstract {
    * @param query_operator query mode
    * @return a multiMatch query builder
    */
-  public BoolQueryBuilder createSemQuery(String input, double T,
-      String query_operator) {
+  public BoolQueryBuilder createSemQuery(String input, double T, String query_operator) {
     Map<String, Double> selected_Map = getRelatedTermsByT(input, T);
     selected_Map.put(input, (double) 1);
 
-    String fieldsList[] = { "Dataset-Metadata", "Dataset-ShortName",
-        "Dataset-LongName", "DatasetParameter-*",
-        "DatasetSource-Source-LongName", "DatasetSource-Source-LongName-Full",
-        "DatasetSource-Source-ShortName", "DatasetSource-Source-ShortName-Full",
-        "DatasetSource-Sensor-LongName", "DatasetSource-Sensor-LongName-Full",
-        "DatasetSource-Sensor-ShortName",
+    String fieldsList[] = { "Dataset-Metadata", "Dataset-ShortName", "Dataset-LongName", "DatasetParameter-*", "DatasetSource-Source-LongName", "DatasetSource-Source-LongName-Full",
+        "DatasetSource-Source-ShortName", "DatasetSource-Source-ShortName-Full", "DatasetSource-Sensor-LongName", "DatasetSource-Sensor-LongName-Full", "DatasetSource-Sensor-ShortName",
         "DatasetSource-Sensor-ShortName-Full" };
     BoolQueryBuilder qb = new BoolQueryBuilder();
     for (Entry<String, Double> entry : selected_Map.entrySet()) {
       if (query_operator.toLowerCase().trim().equals("phrase")) {
-        qb.should(QueryBuilders.multiMatchQuery(entry.getKey(), fieldsList)
-            .boost(entry.getValue().floatValue())
-            .type(MultiMatchQueryBuilder.Type.PHRASE)
-            .tieBreaker((float) 0.5)); // when
+        qb.should(QueryBuilders.multiMatchQuery(entry.getKey(), fieldsList).boost(entry.getValue().floatValue()).type(MultiMatchQueryBuilder.Type.PHRASE).tieBreaker((float) 0.5)); // when
         // set
         // to
         // 1.0,
@@ -119,15 +111,9 @@ public class Dispatcher extends MudrodAbstract {
         // fields"
         // query
       } else if (query_operator.toLowerCase().trim().equals("and")) {
-        qb.should(QueryBuilders.multiMatchQuery(entry.getKey(), fieldsList)
-            .boost(entry.getValue().floatValue())
-            .operator(MatchQueryBuilder.DEFAULT_OPERATOR.AND)
-            .tieBreaker((float) 0.5));
+        qb.should(QueryBuilders.multiMatchQuery(entry.getKey(), fieldsList).boost(entry.getValue().floatValue()).operator(MatchQueryBuilder.DEFAULT_OPERATOR.AND).tieBreaker((float) 0.5));
       } else {
-        qb.should(QueryBuilders.multiMatchQuery(entry.getKey(), fieldsList)
-            .boost(entry.getValue().floatValue())
-            .operator(MatchQueryBuilder.DEFAULT_OPERATOR.OR)
-            .tieBreaker((float) 0.5));
+        qb.should(QueryBuilders.multiMatchQuery(entry.getKey(), fieldsList).boost(entry.getValue().floatValue()).operator(MatchQueryBuilder.DEFAULT_OPERATOR.OR).tieBreaker((float) 0.5));
       }
     }
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/Ranker.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/Ranker.java
@@ -39,12 +39,10 @@ public class Ranker extends MudrodAbstract implements Serializable {
   String learnerType = null;
   Learner le = null;
 
-  public Ranker(Properties props, ESDriver es, SparkDriver spark,
-      String learnerType) {
+  public Ranker(Properties props, ESDriver es, SparkDriver spark, String learnerType) {
     super(props, es, spark);
     this.learnerType = learnerType;
-    le = new Learner(learnerType, spark,
-        props.getProperty(MudrodConstants.SVM_SGD_MODEL));
+    le = new Learner(learnerType, spark, props.getProperty(MudrodConstants.SVM_SGD_MODEL));
   }
 
   /**
@@ -187,8 +185,7 @@ public class Ranker extends MudrodAbstract implements Serializable {
     double[] ins = instList.stream().mapToDouble(i -> i).toArray();
     LabeledPoint insPoint = new LabeledPoint(99.0, Vectors.dense(ins));
     double prediction = le.classify(insPoint);
-    if (equalComp(prediction,
-        1)) { //different from weka where the return value is 1 or 2
+    if (equalComp(prediction, 1)) { //different from weka where the return value is 1 or 2
       return 0;
     } else {
       return 1;

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ranking/DataGenerator.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ranking/DataGenerator.java
@@ -138,13 +138,11 @@ public class DataGenerator {
     List<List<String>> listofLists = new ArrayList<List<String>>(); // Holds calculations 
 
     int rowStart = 1;
-    for (int row = rowStart;
-         row < arr.length; row++) // Start at row 1 because row 0 is heading lol
+    for (int row = rowStart; row < arr.length; row++) // Start at row 1 because row 0 is heading lol
     {
       for (int i = 1; i < arr.length - row; i++) {
         List<String> colList = new ArrayList<String>(); // create vector to store all values inside of a column, which is stored inside 2D vector
-        for (int col = 0; col < arr[0].length
-            - 1; col++) // Columns go until the next to last column
+        for (int col = 0; col < arr[0].length - 1; col++) // Columns go until the next to last column
         {
           //System.out.println(col + " " + arr[row][col]);
           // Extract double value from each cell
@@ -160,16 +158,13 @@ public class DataGenerator {
         }
 
         // Finally, add either 1, -1, or do not add row at all when encountering evaluation value
-        int addEvalNum = compareEvaluation(arr[row][arr[0].length - 1],
-            arr[row + i][arr[0].length - 1]);
+        int addEvalNum = compareEvaluation(arr[row][arr[0].length - 1], arr[row + i][arr[0].length - 1]);
         if (addEvalNum == 1) {
           colList.add("1");
-          listofLists.add(
-              colList); // Add this list to 2D list - row is finished now, move on
+          listofLists.add(colList); // Add this list to 2D list - row is finished now, move on
         } else if (addEvalNum == -1) {
           colList.add("-1");
-          listofLists.add(
-              colList); // Add this list to 2D list - row is finished now, move on
+          listofLists.add(colList); // Add this list to 2D list - row is finished now, move on
         }
         // Else, they are equal, do not even add this row to 2D vector
       }
@@ -217,11 +212,9 @@ public class DataGenerator {
     List<Integer> pos1List = new ArrayList<Integer>();
     List<Integer> neg1List = new ArrayList<Integer>();
 
-    for (int i = 0;
-         i < rawList.size(); i++) // Iterate through all rows to get indexes
+    for (int i = 0; i < rawList.size(); i++) // Iterate through all rows to get indexes
     {
-      int evalNum = Integer.parseInt(rawList.get(i).get(
-          rawList.get(0).size() - 1)); // Get 1 or -1 from original array list
+      int evalNum = Integer.parseInt(rawList.get(i).get(rawList.get(0).size() - 1)); // Get 1 or -1 from original array list
       if (evalNum == 1) {
         pos1List.add(i); // Add row index that has 1
       } else if (evalNum == -1) {
@@ -232,48 +225,36 @@ public class DataGenerator {
     int totPosCount = pos1List.size(); // Total # of 1's
     int totNegCount = neg1List.size(); // Total # of -1's
 
-    if ((totPosCount - totNegCount)
-        >= 1) // There are more 1's than -1's, equalize them
+    if ((totPosCount - totNegCount) >= 1) // There are more 1's than -1's, equalize them
     {
       int indexOfPosList = 0; // Start getting indexes from the first index of positive index location list
-      while ((totPosCount - totNegCount)
-          >= 1) // Keep going until we have acceptable amount of both +1 and -1
+      while ((totPosCount - totNegCount) >= 1) // Keep going until we have acceptable amount of both +1 and -1
       {
-        int pos1IndexVal = pos1List.get(
-            indexOfPosList); // Get index from previously made list of indexes
-        for (int col = 0; col < rawList.get(0)
-            .size(); col++) // Go through elements of indexed row, negating it to transform to -1 row
+        int pos1IndexVal = pos1List.get(indexOfPosList); // Get index from previously made list of indexes
+        for (int col = 0; col < rawList.get(0).size(); col++) // Go through elements of indexed row, negating it to transform to -1 row
         {
-          double d = Double.parseDouble(
-              rawList.get(pos1IndexVal).get(col)); // Transform to double first
+          double d = Double.parseDouble(rawList.get(pos1IndexVal).get(col)); // Transform to double first
           d = d * -1; // Negate it
           String negatedValue = Double.toString(d); // Change back to String
-          rawList.get(pos1IndexVal)
-              .set(col, negatedValue);// Put this value back into dat row
+          rawList.get(pos1IndexVal).set(col, negatedValue);// Put this value back into dat row
         }
 
         totPosCount--; // We changed a +1 row to a -1 row, decrement count of positives
         totNegCount++; // Increment count of negatives
         indexOfPosList++; // Get next +1 location in raw data
       }
-    } else if ((totNegCount - totPosCount)
-        > 1) // There are more -1's than 1's, equalize them
+    } else if ((totNegCount - totPosCount) > 1) // There are more -1's than 1's, equalize them
     {
       int indexOfNegList = 0;
-      while ((totNegCount - totPosCount)
-          > 1) // Keep going until we have acceptable amount of both +1 and -1
+      while ((totNegCount - totPosCount) > 1) // Keep going until we have acceptable amount of both +1 and -1
       {
-        int neg1IndexVal = neg1List.get(
-            indexOfNegList); // Get index from previously made list of indexes
-        for (int col = 0; col < rawList.get(0)
-            .size(); col++) // Go through elements of indexed row, negating it to transform to +1 row
+        int neg1IndexVal = neg1List.get(indexOfNegList); // Get index from previously made list of indexes
+        for (int col = 0; col < rawList.get(0).size(); col++) // Go through elements of indexed row, negating it to transform to +1 row
         {
-          double d = Double.parseDouble(
-              rawList.get(neg1IndexVal).get(col)); // Transform to double first
+          double d = Double.parseDouble(rawList.get(neg1IndexVal).get(col)); // Transform to double first
           d = d * -1; // Negate it
           String negatedValue = Double.toString(d); // Change back to String
-          rawList.get(neg1IndexVal)
-              .set(col, negatedValue);// Put this value back into dat row
+          rawList.get(neg1IndexVal).set(col, negatedValue);// Put this value back into dat row
         }
 
         totNegCount--; // We changed a -1 row to a +1 row, decrement count of negatives now
@@ -310,18 +291,14 @@ public class DataGenerator {
     boolean alreadyExists = new File(outputFile).exists();
 
     try {
-      CSVWriter csvOutput = new CSVWriter(new FileWriter(outputFile),
-          ','); // Create new instance of CSVWriter to write to file output
+      CSVWriter csvOutput = new CSVWriter(new FileWriter(outputFile), ','); // Create new instance of CSVWriter to write to file output
 
       if (!alreadyExists) {
-        csvOutput
-            .writeNext(myHeader); // Write the text headers first before data
+        csvOutput.writeNext(myHeader); // Write the text headers first before data
 
-        for (int i = 0;
-             i < list.size(); i++) // Iterate through all rows in 2D array
+        for (int i = 0; i < list.size(); i++) // Iterate through all rows in 2D array
         {
-          String[] temp = new String[list.get(i)
-              .size()]; // Convert row array list in 2D array to regular string array
+          String[] temp = new String[list.get(i).size()]; // Convert row array list in 2D array to regular string array
           temp = list.get(i).toArray(temp);
           csvOutput.writeNext(temp); // Write this array to the file
         }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ranking/Evaluator.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ranking/Evaluator.java
@@ -134,8 +134,7 @@ public class Evaluator {
         return o2.compareTo(o1);
       }
     };
-    List<Integer> sortlist = IntStream.of(list).boxed()
-        .collect(Collectors.toList());
+    List<Integer> sortlist = IntStream.of(list).boxed().collect(Collectors.toList());
     ;
     Collections.sort(sortlist, comparator);
     int[] sortedArr = sortlist.stream().mapToInt(i -> i).toArray();

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ranking/SparkFormatter.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ranking/SparkFormatter.java
@@ -9,8 +9,7 @@ public class SparkFormatter {
   public SparkFormatter() {
   }
 
-  public void toSparkSVMformat(String inputCSVFileName,
-      String outputTXTFileName) {
+  public void toSparkSVMformat(String inputCSVFileName, String outputTXTFileName) {
     File file = new File(outputTXTFileName);
     if (file.exists()) {
       file.delete();
@@ -26,8 +25,7 @@ public class SparkFormatter {
       while (line != null) {
         String[] list = line.split(",");
         String output = "";
-        Double label = Double
-            .parseDouble(list[list.length - 1].replace("\"", ""));
+        Double label = Double.parseDouble(list[list.length - 1].replace("\"", ""));
         if (label == -1.0) {
           output = "0 ";
         } else if (label == 1.0) {
@@ -36,8 +34,7 @@ public class SparkFormatter {
 
         for (int i = 0; i < list.length - 1; i++) {
           int index = i + 1;
-          output += index + ":" + NDForm
-              .format(Double.parseDouble(list[i].replace("\"", ""))) + " ";
+          output += index + ":" + NDForm.format(Double.parseDouble(list[i].replace("\"", ""))) + " ";
         }
         bw.write(output + "\n");
 
@@ -52,9 +49,7 @@ public class SparkFormatter {
 
   public static void main(String[] args) {
     SparkFormatter sf = new SparkFormatter();
-    sf.toSparkSVMformat(
-        "C:/mudrodCoreTestData/rankingResults/inputDataForSVM.csv",
-        "C:/mudrodCoreTestData/rankingResults/inputDataForSVM_spark.txt");
+    sf.toSparkSVMformat("C:/mudrodCoreTestData/rankingResults/inputDataForSVM.csv", "C:/mudrodCoreTestData/rankingResults/inputDataForSVM_spark.txt");
   }
 
 }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ranking/SparkSVM.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ranking/SparkSVM.java
@@ -32,19 +32,15 @@ public class SparkSVM {
 
     JavaSparkContext jsc = me.startSparkDriver().sc;
 
-    String path = SparkSVM.class.getClassLoader()
-        .getResource("inputDataForSVM_spark.txt").toString();
-    JavaRDD<LabeledPoint> data = MLUtils.loadLibSVMFile(jsc.sc(), path)
-        .toJavaRDD();
+    String path = SparkSVM.class.getClassLoader().getResource("inputDataForSVM_spark.txt").toString();
+    JavaRDD<LabeledPoint> data = MLUtils.loadLibSVMFile(jsc.sc(), path).toJavaRDD();
 
     // Run training algorithm to build the model.
     int numIterations = 100;
     final SVMModel model = SVMWithSGD.train(data.rdd(), numIterations);
 
     // Save and load model
-    model.save(jsc.sc(),
-        SparkSVM.class.getClassLoader().getResource("javaSVMWithSGDModel")
-            .toString());
+    model.save(jsc.sc(), SparkSVM.class.getClassLoader().getResource("javaSVMWithSGDModel").toString());
 
     jsc.sc().stop();
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ranking/TrainingImporter.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/ranking/TrainingImporter.java
@@ -40,8 +40,7 @@ public class TrainingImporter extends MudrodAbstract {
 
   public TrainingImporter(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
-    es.deleteAllByQuery(props.getProperty(MudrodConstants.ES_INDEX_NAME),
-        "trainingranking", QueryBuilders.matchAllQuery());
+    es.deleteAllByQuery(props.getProperty(MudrodConstants.ES_INDEX_NAME), "trainingranking", QueryBuilders.matchAllQuery());
     addMapping();
   }
 
@@ -51,17 +50,11 @@ public class TrainingImporter extends MudrodAbstract {
   public void addMapping() {
     XContentBuilder Mapping;
     try {
-      Mapping = jsonBuilder().startObject().startObject("trainingranking")
-          .startObject("properties").startObject("query")
-          .field("type", "string").field("index", "not_analyzed").endObject()
-          .startObject("dataID").field("type", "string")
-          .field("index", "not_analyzed").endObject().startObject("label")
-          .field("type", "string").field("index", "not_analyzed").endObject()
-          .endObject().endObject().endObject();
+      Mapping = jsonBuilder().startObject().startObject("trainingranking").startObject("properties").startObject("query").field("type", "string").field("index", "not_analyzed").endObject()
+          .startObject("dataID").field("type", "string").field("index", "not_analyzed").endObject().startObject("label").field("type", "string").field("index", "not_analyzed").endObject().endObject()
+          .endObject().endObject();
 
-      es.getClient().admin().indices()
-          .preparePutMapping(props.getProperty("indexName"))
-          .setType("trainingranking").setSource(Mapping).execute().actionGet();
+      es.getClient().admin().indices().preparePutMapping(props.getProperty("indexName")).setType("trainingranking").setSource(Mapping).execute().actionGet();
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -78,19 +71,15 @@ public class TrainingImporter extends MudrodAbstract {
 
     File[] files = new File(dataFolder).listFiles();
     for (File file : files) {
-      BufferedReader br = new BufferedReader(
-          new FileReader(file.getAbsolutePath()));
+      BufferedReader br = new BufferedReader(new FileReader(file.getAbsolutePath()));
       br.readLine();
       String line = br.readLine();
       while (line != null) {
         String[] list = line.split(",");
         String query = file.getName().replace(".csv", "");
         if (list.length > 0) {
-          IndexRequest ir = new IndexRequest(props.getProperty("indexName"),
-              "trainingranking").source(
-              jsonBuilder().startObject().field("query", query)
-                  .field("dataID", list[0])
-                  .field("label", list[list.length - 1]).endObject());
+          IndexRequest ir = new IndexRequest(props.getProperty("indexName"), "trainingranking")
+              .source(jsonBuilder().startObject().field("query", query).field("dataID", list[0]).field("label", list[list.length - 1]).endObject());
           es.getBulkProcessor().add(ir);
         }
         line = br.readLine();

--- a/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/structure/SResult.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/structure/SResult.java
@@ -72,7 +72,7 @@ public class SResult {
 
   public Double prediction = 0.0;
   public String label = null;
-  
+
   //add by quintinali
   public String startDate;
   public String endDate;
@@ -85,8 +85,7 @@ public class SResult {
    * @param description description of dataset
    * @param date        release date of dataset
    */
-  public SResult(String shortName, String longName, String topic,
-      String description, String date) {
+  public SResult(String shortName, String longName, String topic, String description, String date) {
     this.shortName = shortName;
     this.longName = longName;
     this.topic = topic;
@@ -139,8 +138,7 @@ public class SResult {
    * @param fieldValue field value that needs to be set to
    * @return 1 means success, and 0 otherwise
    */
-  public static boolean set(Object object, String fieldName,
-      Object fieldValue) {
+  public static boolean set(Object object, String fieldName, Object fieldValue) {
     Class<?> clazz = object.getClass();
     while (clazz != null) {
       try {

--- a/core/src/main/java/gov/nasa/jpl/mudrod/utils/ESTransportClient.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/utils/ESTransportClient.java
@@ -35,20 +35,15 @@ import java.util.Collections;
 public class ESTransportClient extends TransportClient {
 
   private static final Collection<Class<? extends Plugin>> PRE_INSTALLED_PLUGINS = Collections
-      .unmodifiableList(Arrays
-          .asList(ReindexPlugin.class, PercolatorPlugin.class,
-              MustachePlugin.class, Netty3Plugin.class));
+      .unmodifiableList(Arrays.asList(ReindexPlugin.class, PercolatorPlugin.class, MustachePlugin.class, Netty3Plugin.class));
 
   @SafeVarargs
-  public ESTransportClient(Settings settings,
-      Class<? extends Plugin>... plugins) {
+  public ESTransportClient(Settings settings, Class<? extends Plugin>... plugins) {
     this(settings, Arrays.asList(plugins));
   }
 
-  public ESTransportClient(Settings settings,
-      Collection<Class<? extends Plugin>> plugins) {
-    super(settings, Settings.EMPTY, addPlugins(plugins, PRE_INSTALLED_PLUGINS),
-        null);
+  public ESTransportClient(Settings settings, Collection<Class<? extends Plugin>> plugins) {
+    super(settings, Settings.EMPTY, addPlugins(plugins, PRE_INSTALLED_PLUGINS), null);
 
   }
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/utils/MatrixUtil.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/utils/MatrixUtil.java
@@ -63,8 +63,7 @@ public class MatrixUtil {
       dimension = matrixCol;
     }
 
-    SingularValueDecomposition<RowMatrix, Matrix> svd = tfidfMatrix
-        .computeSVD(dimension, true, 1.0E-9d);
+    SingularValueDecomposition<RowMatrix, Matrix> svd = tfidfMatrix.computeSVD(dimension, true, 1.0E-9d);
     RowMatrix u = svd.U();
     Vector s = svd.s();
     return u.multiply(Matrices.diag(s));
@@ -79,11 +78,9 @@ public class MatrixUtil {
    * feature space, each cell is value of the term in the corresponding
    * dimension.
    */
-  public static RowMatrix buildSVDMatrix(JavaRDD<Vector> vecRDD,
-      int dimension) {
+  public static RowMatrix buildSVDMatrix(JavaRDD<Vector> vecRDD, int dimension) {
     RowMatrix tfidfMatrix = new RowMatrix(vecRDD.rdd());
-    SingularValueDecomposition<RowMatrix, Matrix> svd = tfidfMatrix
-        .computeSVD(dimension, true, 1.0E-9d);
+    SingularValueDecomposition<RowMatrix, Matrix> svd = tfidfMatrix.computeSVD(dimension, true, 1.0E-9d);
     RowMatrix u = svd.U();
     Vector s = svd.s();
     return u.multiply(Matrices.diag(s));
@@ -99,8 +96,7 @@ public class MatrixUtil {
    * and each cell is the TF-IDF value of the term in the corresponding
    * document.
    */
-  public static RowMatrix createTFIDFMatrix(RowMatrix wordDocMatrix,
-      JavaSparkContext sc) {
+  public static RowMatrix createTFIDFMatrix(RowMatrix wordDocMatrix, JavaSparkContext sc) {
     JavaRDD<Vector> newcountRDD = wordDocMatrix.rows().toJavaRDD();
     IDFModel idfModel = new IDF().fit(newcountRDD);
     JavaRDD<Vector> idf = idfModel.transform(newcountRDD);
@@ -115,107 +111,89 @@ public class MatrixUtil {
    * @param sc           spark context
    * @return LabeledRowMatrix {@link LabeledRowMatrix}
    */
-  public static LabeledRowMatrix createWordDocMatrix(
-      JavaPairRDD<String, List<String>> uniqueDocRDD, JavaSparkContext sc) {
+  public static LabeledRowMatrix createWordDocMatrix(JavaPairRDD<String, List<String>> uniqueDocRDD, JavaSparkContext sc) {
     // Index documents with unique IDs
-    JavaPairRDD<List<String>, Long> corpus = uniqueDocRDD.values()
-        .zipWithIndex();
+    JavaPairRDD<List<String>, Long> corpus = uniqueDocRDD.values().zipWithIndex();
     // cal word-doc numbers
-    JavaPairRDD<Tuple2<String, Long>, Double> worddoc_num_RDD = corpus
-        .flatMapToPair(
-            new PairFlatMapFunction<Tuple2<List<String>, Long>, Tuple2<String, Long>, Double>() {
-              /**
-               *
-               */
-              private static final long serialVersionUID = 1L;
+    JavaPairRDD<Tuple2<String, Long>, Double> worddoc_num_RDD = corpus.flatMapToPair(new PairFlatMapFunction<Tuple2<List<String>, Long>, Tuple2<String, Long>, Double>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-              @Override
-              public Iterator<Tuple2<Tuple2<String, Long>, Double>> call(
-                  Tuple2<List<String>, Long> docwords) throws Exception {
-                List<Tuple2<Tuple2<String, Long>, Double>> pairs = new ArrayList<Tuple2<Tuple2<String, Long>, Double>>();
-                List<String> words = docwords._1;
-                int n = words.size();
-                for (int i = 0; i < n; i++) {
-                  Tuple2<String, Long> worddoc = new Tuple2<String, Long>(
-                      words.get(i), docwords._2);
-                  pairs.add(
-                      new Tuple2<Tuple2<String, Long>, Double>(worddoc, 1.0));
-                }
-                return pairs.iterator();
-              }
-            }).reduceByKey(new Function2<Double, Double, Double>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+      @Override
+      public Iterator<Tuple2<Tuple2<String, Long>, Double>> call(Tuple2<List<String>, Long> docwords) throws Exception {
+        List<Tuple2<Tuple2<String, Long>, Double>> pairs = new ArrayList<Tuple2<Tuple2<String, Long>, Double>>();
+        List<String> words = docwords._1;
+        int n = words.size();
+        for (int i = 0; i < n; i++) {
+          Tuple2<String, Long> worddoc = new Tuple2<String, Long>(words.get(i), docwords._2);
+          pairs.add(new Tuple2<Tuple2<String, Long>, Double>(worddoc, 1.0));
+        }
+        return pairs.iterator();
+      }
+    }).reduceByKey(new Function2<Double, Double, Double>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Double call(Double first, Double second) throws Exception {
-            return first + second;
-          }
-        });
+      @Override
+      public Double call(Double first, Double second) throws Exception {
+        return first + second;
+      }
+    });
     // cal word doc-numbers
     JavaPairRDD<String, Tuple2<List<Long>, List<Double>>> word_docnum_RDD = worddoc_num_RDD
-        .mapToPair(
-            new PairFunction<Tuple2<Tuple2<String, Long>, Double>, String, Tuple2<List<Long>, List<Double>>>() {
-              /**
-               *
-               */
-              private static final long serialVersionUID = 1L;
-
-              @Override
-              public Tuple2<String, Tuple2<List<Long>, List<Double>>> call(
-                  Tuple2<Tuple2<String, Long>, Double> worddoc_num)
-                  throws Exception {
-                List<Long> docs = new ArrayList<Long>();
-                docs.add(worddoc_num._1._2);
-                List<Double> nums = new ArrayList<Double>();
-                nums.add(worddoc_num._2);
-                Tuple2<List<Long>, List<Double>> docmums = new Tuple2<List<Long>, List<Double>>(
-                    docs, nums);
-                return new Tuple2<String, Tuple2<List<Long>, List<Double>>>(
-                    worddoc_num._1._1, docmums);
-              }
-            });
-    // trans to vector
-    final int corporsize = (int) uniqueDocRDD.keys().count();
-    JavaPairRDD<String, Vector> word_vectorRDD = word_docnum_RDD.reduceByKey(
-        new Function2<Tuple2<List<Long>, List<Double>>, Tuple2<List<Long>, List<Double>>, Tuple2<List<Long>, List<Double>>>() {
+        .mapToPair(new PairFunction<Tuple2<Tuple2<String, Long>, Double>, String, Tuple2<List<Long>, List<Double>>>() {
           /**
            *
            */
           private static final long serialVersionUID = 1L;
 
           @Override
-          public Tuple2<List<Long>, List<Double>> call(
-              Tuple2<List<Long>, List<Double>> arg0,
-              Tuple2<List<Long>, List<Double>> arg1) throws Exception {
-            arg0._1.addAll(arg1._1);
-            arg0._2.addAll(arg1._2);
-            return new Tuple2<List<Long>, List<Double>>(arg0._1, arg0._2);
-          }
-        }).mapToPair(
-        new PairFunction<Tuple2<String, Tuple2<List<Long>, List<Double>>>, String, Vector>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
-
-          @Override
-          public Tuple2<String, Vector> call(
-              Tuple2<String, Tuple2<List<Long>, List<Double>>> arg0)
-              throws Exception {
-            int docsize = arg0._2._1.size();
-            int[] intArray = new int[docsize];
-            double[] doubleArray = new double[docsize];
-            for (int i = 0; i < docsize; i++) {
-              intArray[i] = arg0._2._1.get(i).intValue();
-              doubleArray[i] = arg0._2._2.get(i).intValue();
-            }
-            Vector sv = Vectors.sparse(corporsize, intArray, doubleArray);
-            return new Tuple2<String, Vector>(arg0._1, sv);
+          public Tuple2<String, Tuple2<List<Long>, List<Double>>> call(Tuple2<Tuple2<String, Long>, Double> worddoc_num) throws Exception {
+            List<Long> docs = new ArrayList<Long>();
+            docs.add(worddoc_num._1._2);
+            List<Double> nums = new ArrayList<Double>();
+            nums.add(worddoc_num._2);
+            Tuple2<List<Long>, List<Double>> docmums = new Tuple2<List<Long>, List<Double>>(docs, nums);
+            return new Tuple2<String, Tuple2<List<Long>, List<Double>>>(worddoc_num._1._1, docmums);
           }
         });
+    // trans to vector
+    final int corporsize = (int) uniqueDocRDD.keys().count();
+    JavaPairRDD<String, Vector> word_vectorRDD = word_docnum_RDD.reduceByKey(new Function2<Tuple2<List<Long>, List<Double>>, Tuple2<List<Long>, List<Double>>, Tuple2<List<Long>, List<Double>>>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public Tuple2<List<Long>, List<Double>> call(Tuple2<List<Long>, List<Double>> arg0, Tuple2<List<Long>, List<Double>> arg1) throws Exception {
+        arg0._1.addAll(arg1._1);
+        arg0._2.addAll(arg1._2);
+        return new Tuple2<List<Long>, List<Double>>(arg0._1, arg0._2);
+      }
+    }).mapToPair(new PairFunction<Tuple2<String, Tuple2<List<Long>, List<Double>>>, String, Vector>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public Tuple2<String, Vector> call(Tuple2<String, Tuple2<List<Long>, List<Double>>> arg0) throws Exception {
+        int docsize = arg0._2._1.size();
+        int[] intArray = new int[docsize];
+        double[] doubleArray = new double[docsize];
+        for (int i = 0; i < docsize; i++) {
+          intArray[i] = arg0._2._1.get(i).intValue();
+          doubleArray[i] = arg0._2._2.get(i).intValue();
+        }
+        Vector sv = Vectors.sparse(corporsize, intArray, doubleArray);
+        return new Tuple2<String, Vector>(arg0._1, sv);
+      }
+    });
 
     RowMatrix wordDocMatrix = new RowMatrix(word_vectorRDD.values().rdd());
 
@@ -226,152 +204,127 @@ public class MatrixUtil {
     return labeledRowMatrix;
   }
 
-  public static LabeledRowMatrix createDocWordMatrix(
-      JavaPairRDD<String, List<String>> uniqueDocRDD, JavaSparkContext sc) {
+  public static LabeledRowMatrix createDocWordMatrix(JavaPairRDD<String, List<String>> uniqueDocRDD, JavaSparkContext sc) {
     // Index word with unique IDs
-    JavaPairRDD<String, Long> wordIDRDD = uniqueDocRDD.values()
-        .flatMap(new FlatMapFunction<List<String>, String>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+    JavaPairRDD<String, Long> wordIDRDD = uniqueDocRDD.values().flatMap(new FlatMapFunction<List<String>, String>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Iterator<String> call(List<String> arg0) throws Exception {
-            return arg0.iterator();
-          }
-        }).distinct().zipWithIndex();
-
-    //
-    JavaPairRDD<Tuple2<String, String>, Double> docword_num_RDD = uniqueDocRDD
-        .flatMapToPair(
-            new PairFlatMapFunction<Tuple2<String, List<String>>, Tuple2<String, String>, Double>() {
-
-              /**
-               *
-               */
-              private static final long serialVersionUID = 1L;
-
-              @Override
-              public Iterator<Tuple2<Tuple2<String, String>, Double>> call(
-                  Tuple2<String, List<String>> docwords) throws Exception {
-                List<Tuple2<Tuple2<String, String>, Double>> pairs = new ArrayList<Tuple2<Tuple2<String, String>, Double>>();
-                List<String> words = docwords._2;
-                int n = words.size();
-                for (int i = 0; i < n; i++) {
-                  Tuple2<String, String> worddoc = new Tuple2<String, String>(
-                      docwords._1, words.get(i));
-                  pairs.add(
-                      new Tuple2<Tuple2<String, String>, Double>(worddoc, 1.0));
-                }
-                return pairs.iterator();
-              }
-            }).reduceByKey(new Function2<Double, Double, Double>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
-
-          @Override
-          public Double call(Double first, Double second) throws Exception {
-            return first + second;
-          }
-        });
+      @Override
+      public Iterator<String> call(List<String> arg0) throws Exception {
+        return arg0.iterator();
+      }
+    }).distinct().zipWithIndex();
 
     //
-    JavaPairRDD<String, Tuple2<String, Double>> word_docnum_RDD = docword_num_RDD
-        .mapToPair(
-            new PairFunction<Tuple2<Tuple2<String, String>, Double>, String, Tuple2<String, Double>>() {
-              /**
-               *
-               */
-              private static final long serialVersionUID = 1L;
+    JavaPairRDD<Tuple2<String, String>, Double> docword_num_RDD = uniqueDocRDD.flatMapToPair(new PairFlatMapFunction<Tuple2<String, List<String>>, Tuple2<String, String>, Double>() {
 
-              @Override
-              public Tuple2<String, Tuple2<String, Double>> call(
-                  Tuple2<Tuple2<String, String>, Double> arg0)
-                  throws Exception {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-                Tuple2<String, Double> wordmums = new Tuple2<String, Double>(
-                    arg0._1._1, arg0._2);
-                return new Tuple2<String, Tuple2<String, Double>>(arg0._1._2,
-                    wordmums);
-              }
-            });
+      @Override
+      public Iterator<Tuple2<Tuple2<String, String>, Double>> call(Tuple2<String, List<String>> docwords) throws Exception {
+        List<Tuple2<Tuple2<String, String>, Double>> pairs = new ArrayList<Tuple2<Tuple2<String, String>, Double>>();
+        List<String> words = docwords._2;
+        int n = words.size();
+        for (int i = 0; i < n; i++) {
+          Tuple2<String, String> worddoc = new Tuple2<String, String>(docwords._1, words.get(i));
+          pairs.add(new Tuple2<Tuple2<String, String>, Double>(worddoc, 1.0));
+        }
+        return pairs.iterator();
+      }
+    }).reduceByKey(new Function2<Double, Double, Double>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public Double call(Double first, Double second) throws Exception {
+        return first + second;
+      }
+    });
+
+    //
+    JavaPairRDD<String, Tuple2<String, Double>> word_docnum_RDD = docword_num_RDD.mapToPair(new PairFunction<Tuple2<Tuple2<String, String>, Double>, String, Tuple2<String, Double>>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public Tuple2<String, Tuple2<String, Double>> call(Tuple2<Tuple2<String, String>, Double> arg0) throws Exception {
+
+        Tuple2<String, Double> wordmums = new Tuple2<String, Double>(arg0._1._1, arg0._2);
+        return new Tuple2<String, Tuple2<String, Double>>(arg0._1._2, wordmums);
+      }
+    });
 
     //
 
-    JavaPairRDD<String, Tuple2<Tuple2<String, Double>, Optional<Long>>> testRDD = word_docnum_RDD
-        .leftOuterJoin(wordIDRDD);
+    JavaPairRDD<String, Tuple2<Tuple2<String, Double>, Optional<Long>>> testRDD = word_docnum_RDD.leftOuterJoin(wordIDRDD);
 
     int wordsize = (int) wordIDRDD.count();
-    JavaPairRDD<String, Vector> doc_vectorRDD = testRDD.mapToPair(
-        new PairFunction<Tuple2<String, Tuple2<Tuple2<String, Double>, Optional<Long>>>, String, Tuple2<List<Long>, List<Double>>>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+    JavaPairRDD<String, Vector> doc_vectorRDD = testRDD.mapToPair(new PairFunction<Tuple2<String, Tuple2<Tuple2<String, Double>, Optional<Long>>>, String, Tuple2<List<Long>, List<Double>>>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Tuple2<String, Tuple2<List<Long>, List<Double>>> call(
-              Tuple2<String, Tuple2<Tuple2<String, Double>, Optional<Long>>> arg0)
-              throws Exception {
-            Optional<Long> oid = arg0._2._2;
-            Long wordId = (long) 0;
-            if (oid.isPresent()) {
-              wordId = oid.get();
-            }
+      @Override
+      public Tuple2<String, Tuple2<List<Long>, List<Double>>> call(Tuple2<String, Tuple2<Tuple2<String, Double>, Optional<Long>>> arg0) throws Exception {
+        Optional<Long> oid = arg0._2._2;
+        Long wordId = (long) 0;
+        if (oid.isPresent()) {
+          wordId = oid.get();
+        }
 
-            List<Long> word = new ArrayList<Long>();
-            word.add(wordId);
+        List<Long> word = new ArrayList<Long>();
+        word.add(wordId);
 
-            List<Double> count = new ArrayList<Double>();
-            count.add(arg0._2._1._2);
+        List<Double> count = new ArrayList<Double>();
+        count.add(arg0._2._1._2);
 
-            Tuple2<List<Long>, List<Double>> wordcount = new Tuple2<List<Long>, List<Double>>(
-                word, count);
+        Tuple2<List<Long>, List<Double>> wordcount = new Tuple2<List<Long>, List<Double>>(word, count);
 
-            return new Tuple2<String, Tuple2<List<Long>, List<Double>>>(
-                arg0._2._1._1, wordcount);
-          }
+        return new Tuple2<String, Tuple2<List<Long>, List<Double>>>(arg0._2._1._1, wordcount);
+      }
 
-        }).reduceByKey(
-        new Function2<Tuple2<List<Long>, List<Double>>, Tuple2<List<Long>, List<Double>>, Tuple2<List<Long>, List<Double>>>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+    }).reduceByKey(new Function2<Tuple2<List<Long>, List<Double>>, Tuple2<List<Long>, List<Double>>, Tuple2<List<Long>, List<Double>>>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Tuple2<List<Long>, List<Double>> call(
-              Tuple2<List<Long>, List<Double>> arg0,
-              Tuple2<List<Long>, List<Double>> arg1) throws Exception {
-            arg0._1.addAll(arg1._1);
-            arg0._2.addAll(arg1._2);
-            return new Tuple2<List<Long>, List<Double>>(arg0._1, arg0._2);
-          }
-        }).mapToPair(
-        new PairFunction<Tuple2<String, Tuple2<List<Long>, List<Double>>>, String, Vector>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+      @Override
+      public Tuple2<List<Long>, List<Double>> call(Tuple2<List<Long>, List<Double>> arg0, Tuple2<List<Long>, List<Double>> arg1) throws Exception {
+        arg0._1.addAll(arg1._1);
+        arg0._2.addAll(arg1._2);
+        return new Tuple2<List<Long>, List<Double>>(arg0._1, arg0._2);
+      }
+    }).mapToPair(new PairFunction<Tuple2<String, Tuple2<List<Long>, List<Double>>>, String, Vector>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Tuple2<String, Vector> call(
-              Tuple2<String, Tuple2<List<Long>, List<Double>>> arg0)
-              throws Exception {
-            int docsize = arg0._2._1.size();
-            int[] intArray = new int[docsize];
-            double[] doubleArray = new double[docsize];
-            for (int i = 0; i < docsize; i++) {
-              intArray[i] = arg0._2._1.get(i).intValue();
-              doubleArray[i] = arg0._2._2.get(i).intValue();
-            }
-            Vector sv = Vectors.sparse(wordsize, intArray, doubleArray);
-            return new Tuple2<String, Vector>(arg0._1, sv);
-          }
-        });
+      @Override
+      public Tuple2<String, Vector> call(Tuple2<String, Tuple2<List<Long>, List<Double>>> arg0) throws Exception {
+        int docsize = arg0._2._1.size();
+        int[] intArray = new int[docsize];
+        double[] doubleArray = new double[docsize];
+        for (int i = 0; i < docsize; i++) {
+          intArray[i] = arg0._2._1.get(i).intValue();
+          doubleArray[i] = arg0._2._2.get(i).intValue();
+        }
+        Vector sv = Vectors.sparse(wordsize, intArray, doubleArray);
+        return new Tuple2<String, Vector>(arg0._1, sv);
+      }
+    });
 
     RowMatrix docwordMatrix = new RowMatrix(doc_vectorRDD.values().rdd());
 
@@ -393,42 +346,37 @@ public class MatrixUtil {
    * @return JavaPairRDD, each key is a term, and value is the vector of the
    * term in feature space.
    */
-  public static JavaPairRDD<String, Vector> loadVectorFromCSV(SparkDriver spark,
-      String csvFileName, int skipNum) {
+  public static JavaPairRDD<String, Vector> loadVectorFromCSV(SparkDriver spark, String csvFileName, int skipNum) {
     // skip the first two lines(header), important!
     JavaRDD<String> importRDD = spark.sc.textFile(csvFileName);
-    JavaPairRDD<String, Long> importIdRDD = importRDD.zipWithIndex()
-        .filter(new Function<Tuple2<String, Long>, Boolean>() {
-          /** */
-          private static final long serialVersionUID = 1L;
+    JavaPairRDD<String, Long> importIdRDD = importRDD.zipWithIndex().filter(new Function<Tuple2<String, Long>, Boolean>() {
+      /** */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Boolean call(Tuple2<String, Long> v1) throws Exception {
-            if (v1._2 > (skipNum - 1)) {
-              return true;
-            }
-            return false;
-          }
-        });
+      @Override
+      public Boolean call(Tuple2<String, Long> v1) throws Exception {
+        if (v1._2 > (skipNum - 1)) {
+          return true;
+        }
+        return false;
+      }
+    });
 
-    return importIdRDD
-        .mapToPair(new PairFunction<Tuple2<String, Long>, String, Vector>() {
-          /** */
-          private static final long serialVersionUID = 1L;
+    return importIdRDD.mapToPair(new PairFunction<Tuple2<String, Long>, String, Vector>() {
+      /** */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Tuple2<String, Vector> call(Tuple2<String, Long> t)
-              throws Exception {
-            String[] fields = t._1.split(",");
-            String word = fields[0];
-            int fieldsize = fields.length;
-            String[] numfields = Arrays.copyOfRange(fields, 1, fieldsize - 1);
-            double[] nums = Stream.of(numfields)
-                .mapToDouble(Double::parseDouble).toArray();
-            Vector vec = Vectors.dense(nums);
-            return new Tuple2<>(word, vec);
-          }
-        });
+      @Override
+      public Tuple2<String, Vector> call(Tuple2<String, Long> t) throws Exception {
+        String[] fields = t._1.split(",");
+        String word = fields[0];
+        int fieldsize = fields.length;
+        String[] numfields = Arrays.copyOfRange(fields, 1, fieldsize - 1);
+        double[] nums = Stream.of(numfields).mapToDouble(Double::parseDouble).toArray();
+        Vector vec = Vectors.dense(nums);
+        return new Tuple2<>(word, vec);
+      }
+    });
   }
 
   /**
@@ -438,18 +386,17 @@ public class MatrixUtil {
    * @return IndexedRowMatrix
    */
   public static IndexedRowMatrix buildIndexRowMatrix(JavaRDD<Vector> vecs) {
-    JavaRDD<IndexedRow> indexrows = vecs.zipWithIndex()
-        .map(new Function<Tuple2<Vector, Long>, IndexedRow>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+    JavaRDD<IndexedRow> indexrows = vecs.zipWithIndex().map(new Function<Tuple2<Vector, Long>, IndexedRow>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public IndexedRow call(Tuple2<Vector, Long> docId) {
-            return new IndexedRow(docId._2, docId._1);
-          }
-        });
+      @Override
+      public IndexedRow call(Tuple2<Vector, Long> docId) {
+        return new IndexedRow(docId._2, docId._1);
+      }
+    });
     return new IndexedRowMatrix(indexrows.rdd());
   }
 
@@ -472,8 +419,7 @@ public class MatrixUtil {
    * @param colKeys  matrix coloum names
    * @param fileName csv file name
    */
-  public static void exportToCSV(RowMatrix matrix, List<String> rowKeys,
-      List<String> colKeys, String fileName) {
+  public static void exportToCSV(RowMatrix matrix, List<String> rowKeys, List<String> colKeys, String fileName) {
 
     if (matrix.rows().isEmpty()) {
       return;

--- a/core/src/main/java/gov/nasa/jpl/mudrod/utils/RDDUtil.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/utils/RDDUtil.java
@@ -35,20 +35,18 @@ public class RDDUtil {
    *                   that doc.
    * @return unique term list
    */
-  public static JavaRDD<String> getAllWordsInDoc(
-      JavaPairRDD<String, List<String>> docwordRDD) {
-    JavaRDD<String> wordRDD = docwordRDD.values()
-        .flatMap(new FlatMapFunction<List<String>, String>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+  public static JavaRDD<String> getAllWordsInDoc(JavaPairRDD<String, List<String>> docwordRDD) {
+    JavaRDD<String> wordRDD = docwordRDD.values().flatMap(new FlatMapFunction<List<String>, String>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Iterator<String> call(List<String> list) {
-            return list.iterator();
-          }
-        }).distinct();
+      @Override
+      public Iterator<String> call(List<String> list) {
+        return list.iterator();
+      }
+    }).distinct();
 
     return wordRDD;
   }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/utils/SVDUtil.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/utils/SVDUtil.java
@@ -61,14 +61,11 @@ public class SVDUtil extends MudrodAbstract {
    * @param svdDimension: Dimension of matrix after singular value decomposition
    * @return row matrix
    */
-  public RowMatrix buildSVDMatrix(JavaPairRDD<String, List<String>> docwordRDD,
-      int svdDimension) {
+  public RowMatrix buildSVDMatrix(JavaPairRDD<String, List<String>> docwordRDD, int svdDimension) {
 
     RowMatrix svdMatrix = null;
-    LabeledRowMatrix wordDocMatrix = MatrixUtil
-        .createWordDocMatrix(docwordRDD, spark.sc);
-    RowMatrix ifIdfMatrix = MatrixUtil
-        .createTFIDFMatrix(wordDocMatrix.rowMatrix, spark.sc);
+    LabeledRowMatrix wordDocMatrix = MatrixUtil.createWordDocMatrix(docwordRDD, spark.sc);
+    RowMatrix ifIdfMatrix = MatrixUtil.createTFIDFMatrix(wordDocMatrix.rowMatrix, spark.sc);
     svdMatrix = MatrixUtil.buildSVDMatrix(ifIdfMatrix, svdDimension);
     this.svdMatrix = svdMatrix;
     this.wordRDD = RDDUtil.getAllWordsInDoc(docwordRDD);
@@ -84,8 +81,7 @@ public class SVDUtil extends MudrodAbstract {
    */
   public RowMatrix buildSVDMatrix(String tfidfCSVfile, int svdDimension) {
     RowMatrix svdMatrix = null;
-    JavaPairRDD<String, Vector> tfidfRDD = MatrixUtil
-        .loadVectorFromCSV(spark, tfidfCSVfile, 2);
+    JavaPairRDD<String, Vector> tfidfRDD = MatrixUtil.loadVectorFromCSV(spark, tfidfCSVfile, 2);
     JavaRDD<Vector> vectorRDD = tfidfRDD.values();
 
     svdMatrix = MatrixUtil.buildSVDMatrix(vectorRDD, svdDimension);
@@ -100,8 +96,7 @@ public class SVDUtil extends MudrodAbstract {
    * CalSimilarity: calculate similarity
    */
   public void calSimilarity() {
-    CoordinateMatrix simMatrix = SimilarityUtil
-        .calculateSimilarityFromMatrix(svdMatrix);
+    CoordinateMatrix simMatrix = SimilarityUtil.calculateSimilarityFromMatrix(svdMatrix);
     this.simMatrix = simMatrix;
   }
 
@@ -112,8 +107,7 @@ public class SVDUtil extends MudrodAbstract {
    * @param type  linkage triple name
    */
   public void insertLinkageToES(String index, String type) {
-    List<LinkageTriple> triples = SimilarityUtil
-        .matrixToTriples(wordRDD, simMatrix);
+    List<LinkageTriple> triples = SimilarityUtil.matrixToTriples(wordRDD, simMatrix);
     try {
       LinkageTriple.insertTriples(es, triples, index, type);
     } catch (IOException e) {

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/pre/ClickStreamGenerator.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/pre/ClickStreamGenerator.java
@@ -37,11 +37,9 @@ public class ClickStreamGenerator extends DiscoveryStepAbstract {
    *
    */
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(ClickStreamGenerator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ClickStreamGenerator.class);
 
-  public ClickStreamGenerator(Properties props, ESDriver es,
-      SparkDriver spark) {
+  public ClickStreamGenerator(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
   }
 
@@ -53,23 +51,18 @@ public class ClickStreamGenerator extends DiscoveryStepAbstract {
     String clickstremMatrixFile = props.getProperty("clickstreamMatrix");
     try {
       SessionExtractor extractor = new SessionExtractor();
-      JavaRDD<ClickStream> clickstreamRDD = extractor
-          .extractClickStreamFromES(this.props, this.es, this.spark);
+      JavaRDD<ClickStream> clickstreamRDD = extractor.extractClickStreamFromES(this.props, this.es, this.spark);
       int weight = Integer.parseInt(props.getProperty("downloadWeight"));
-      JavaPairRDD<String, List<String>> metaddataQueryRDD = extractor
-          .bulidDataQueryRDD(clickstreamRDD, weight);
-      LabeledRowMatrix wordDocMatrix = MatrixUtil
-          .createWordDocMatrix(metaddataQueryRDD, spark.sc);
+      JavaPairRDD<String, List<String>> metaddataQueryRDD = extractor.bulidDataQueryRDD(clickstreamRDD, weight);
+      LabeledRowMatrix wordDocMatrix = MatrixUtil.createWordDocMatrix(metaddataQueryRDD, spark.sc);
 
-      MatrixUtil.exportToCSV(wordDocMatrix.rowMatrix, wordDocMatrix.rowkeys,
-          wordDocMatrix.colkeys, clickstremMatrixFile);
+      MatrixUtil.exportToCSV(wordDocMatrix.rowMatrix, wordDocMatrix.rowkeys, wordDocMatrix.colkeys, clickstremMatrixFile);
     } catch (Exception e) {
       e.printStackTrace();
     }
 
     endTime = System.currentTimeMillis();
-    LOG.info("ClickStreamGenerator complete. Time elapsed {} seconds.",
-        (endTime - startTime) / 1000);
+    LOG.info("ClickStreamGenerator complete. Time elapsed {} seconds.", (endTime - startTime) / 1000);
     return null;
   }
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/pre/LogAbstract.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/pre/LogAbstract.java
@@ -50,17 +50,14 @@ public class LogAbstract extends DiscoveryStepAbstract {
   }
 
   protected void initLogIndex() {
-    logIndex = props.getProperty(MudrodConstants.LOG_INDEX) + props
-        .getProperty(MudrodConstants.TIME_SUFFIX);
+    logIndex = props.getProperty(MudrodConstants.LOG_INDEX) + props.getProperty(MudrodConstants.TIME_SUFFIX);
     httpType = props.getProperty(MudrodConstants.HTTP_TYPE_PREFIX);
     ftpType = props.getProperty(MudrodConstants.FTP_TYPE_PREFIX);
     cleanupType = props.getProperty(MudrodConstants.CLEANUP_TYPE_PREFIX);
     sessionStats = props.getProperty(MudrodConstants.SESSION_STATS_PREFIX);
 
-    InputStream settingsStream = getClass().getClassLoader()
-        .getResourceAsStream(ES_SETTINGS);
-    InputStream mappingsStream = getClass().getClassLoader()
-        .getResourceAsStream(ES_MAPPINGS);
+    InputStream settingsStream = getClass().getClassLoader().getResourceAsStream(ES_SETTINGS);
+    InputStream mappingsStream = getClass().getClassLoader().getResourceAsStream(ES_MAPPINGS);
     JSONObject settingsJSON = null;
     JSONObject mappingJSON = null;
 
@@ -78,8 +75,7 @@ public class LogAbstract extends DiscoveryStepAbstract {
 
     try {
       if (settingsJSON != null && mappingJSON != null) {
-        this.es.putMapping(logIndex, settingsJSON.toString(),
-            mappingJSON.toString());
+        this.es.putMapping(logIndex, settingsJSON.toString(), mappingJSON.toString());
       }
     } catch (IOException e) {
       LOG.error("Error entering Elasticsearch Mappings!", e);
@@ -124,10 +120,8 @@ public class LogAbstract extends DiscoveryStepAbstract {
 
     int docCount = es.getDocCount(logIndex, type);
 
-    SearchResponse sr = es.getClient().prepareSearch(logIndex).setTypes(type)
-        .setQuery(QueryBuilders.matchAllQuery()).setSize(0).addAggregation(
-            AggregationBuilders.terms("Users").field("IP").size(docCount))
-        .execute().actionGet();
+    SearchResponse sr = es.getClient().prepareSearch(logIndex).setTypes(type).setQuery(QueryBuilders.matchAllQuery()).setSize(0)
+        .addAggregation(AggregationBuilders.terms("Users").field("IP").size(docCount)).execute().actionGet();
     Terms users = sr.getAggregations().get("Users");
 
     return users;
@@ -150,15 +144,10 @@ public class LogAbstract extends DiscoveryStepAbstract {
 
     int docCount = es.getDocCount(logIndex, httpType);
 
-    AggregationBuilder dailyAgg = AggregationBuilders.dateHistogram("by_day")
-        .field("Time").dateHistogramInterval(DateHistogramInterval.DAY)
-        .order(Order.COUNT_DESC);
+    AggregationBuilder dailyAgg = AggregationBuilders.dateHistogram("by_day").field("Time").dateHistogramInterval(DateHistogramInterval.DAY).order(Order.COUNT_DESC);
 
-    SearchResponse sr = es.getClient().prepareSearch(logIndex)
-        .setTypes(httpType).setQuery(QueryBuilders.matchAllQuery()).setSize(0)
-        .addAggregation(
-            AggregationBuilders.terms("Users").field("IP").size(docCount)
-                .subAggregation(dailyAgg)).execute().actionGet();
+    SearchResponse sr = es.getClient().prepareSearch(logIndex).setTypes(httpType).setQuery(QueryBuilders.matchAllQuery()).setSize(0)
+        .addAggregation(AggregationBuilders.terms("Users").field("IP").size(docCount).subAggregation(dailyAgg)).execute().actionGet();
     Terms users = sr.getAggregations().get("Users");
     Map<String, Long> userList = new HashMap<String, Long>();
     for (Terms.Bucket user : users.getBuckets()) {
@@ -212,8 +201,7 @@ public class LogAbstract extends DiscoveryStepAbstract {
     Map<String, Integer> UserGroups = solution.solve(userDocs, this.partition);
 
     JavaPairRDD<String, Double> pairRdd = spark.sc.parallelizePairs(list);
-    JavaPairRDD<String, Double> userPairRDD = pairRdd
-        .partitionBy(new logPartitioner(UserGroups, this.partition));
+    JavaPairRDD<String, Double> userPairRDD = pairRdd.partitionBy(new logPartitioner(UserGroups, this.partition));
 
     // repartitioned user RDD
     JavaRDD<String> userRDD = userPairRDD.keys();
@@ -226,10 +214,8 @@ public class LogAbstract extends DiscoveryStepAbstract {
 
     int docCount = es.getDocCount(this.logIndex, this.cleanupType);
 
-    SearchResponse sr = es.getClient().prepareSearch(this.logIndex)
-        .setTypes(this.cleanupType).setQuery(QueryBuilders.matchAllQuery())
-        .addAggregation(AggregationBuilders.terms("Sessions").field("SessionID")
-            .size(docCount)).execute().actionGet();
+    SearchResponse sr = es.getClient().prepareSearch(this.logIndex).setTypes(this.cleanupType).setQuery(QueryBuilders.matchAllQuery())
+        .addAggregation(AggregationBuilders.terms("Sessions").field("SessionID").size(docCount)).execute().actionGet();
 
     Terms Sessions = sr.getAggregations().get("Sessions");
     return Sessions;

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/pre/RankingTrainDataGenerator.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/pre/RankingTrainDataGenerator.java
@@ -14,11 +14,9 @@ import java.util.Properties;
 public class RankingTrainDataGenerator extends DiscoveryStepAbstract {
 
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(RankingTrainDataGenerator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RankingTrainDataGenerator.class);
 
-  public RankingTrainDataGenerator(Properties props, ESDriver es,
-      SparkDriver spark) {
+  public RankingTrainDataGenerator(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
     // TODO Auto-generated constructor stub
   }
@@ -32,22 +30,18 @@ public class RankingTrainDataGenerator extends DiscoveryStepAbstract {
     String rankingTrainFile = "E:\\Mudrod_input_data\\Testing_Data_4_1monthLog+Meta+Onto\\traing.txt";
     try {
       SessionExtractor extractor = new SessionExtractor();
-      JavaRDD<RankingTrainData> rankingTrainDataRDD = extractor
-          .extractRankingTrainData(this.props, this.es, this.spark);
+      JavaRDD<RankingTrainData> rankingTrainDataRDD = extractor.extractRankingTrainData(this.props, this.es, this.spark);
 
-      JavaRDD<String> rankingTrainData_JsonRDD = rankingTrainDataRDD
-          .map(f -> f.toJson());
+      JavaRDD<String> rankingTrainData_JsonRDD = rankingTrainDataRDD.map(f -> f.toJson());
 
-      rankingTrainData_JsonRDD.coalesce(1, true)
-          .saveAsTextFile(rankingTrainFile);
+      rankingTrainData_JsonRDD.coalesce(1, true).saveAsTextFile(rankingTrainFile);
 
     } catch (Exception e) {
       e.printStackTrace();
     }
 
     endTime = System.currentTimeMillis();
-    LOG.info("Ranking train data generation complete. Time elapsed {} seconds.",
-        (endTime - startTime) / 1000);
+    LOG.info("Ranking train data generation complete. Time elapsed {} seconds.", (endTime - startTime) / 1000);
     return null;
   }
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/pre/RemoveRawLog.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/pre/RemoveRawLog.java
@@ -44,8 +44,7 @@ public class RemoveRawLog extends LogAbstract {
     es.deleteAllByQuery(logIndex, ftpType, QueryBuilders.matchAllQuery());
     endTime = System.currentTimeMillis();
     es.refreshIndex();
-    LOG.info("Raw log removal complete. Time elapsed {} seconds.",
-        (endTime - startTime) / 1000);
+    LOG.info("Raw log removal complete. Time elapsed {} seconds.", (endTime - startTime) / 1000);
     return null;
   }
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/pre/SessionGenerator.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/pre/SessionGenerator.java
@@ -55,8 +55,7 @@ public class SessionGenerator extends LogAbstract {
    *
    */
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(SessionGenerator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SessionGenerator.class);
 
   public SessionGenerator(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
@@ -69,8 +68,7 @@ public class SessionGenerator extends LogAbstract {
     generateSession();
     endTime = System.currentTimeMillis();
     es.refreshIndex();
-    LOG.info("Session generating complete. Time elapsed {} seconds.",
-        (endTime - startTime) / 1000);
+    LOG.info("Session generating complete. Time elapsed {} seconds.", (endTime - startTime) / 1000);
     return null;
   }
 
@@ -94,8 +92,7 @@ public class SessionGenerator extends LogAbstract {
     }
   }
 
-  public void genSessionByReferer(int timeThres)
-      throws InterruptedException, IOException {
+  public void genSessionByReferer(int timeThres) throws InterruptedException, IOException {
     String processingType = props.getProperty("processingType");
     if (processingType.equals(MudrodConstants.SEQUENTIAL_PROCESS)) {
       genSessionByRefererInSequential(timeThres);
@@ -104,8 +101,7 @@ public class SessionGenerator extends LogAbstract {
     }
   }
 
-  public void combineShortSessions(int timeThres)
-      throws InterruptedException, IOException {
+  public void combineShortSessions(int timeThres) throws InterruptedException, IOException {
     String processingType = props.getProperty("processingType");
     if (processingType.equals(MudrodConstants.SEQUENTIAL_PROCESS)) {
       combineShortSessionsInSequential(timeThres);
@@ -121,8 +117,7 @@ public class SessionGenerator extends LogAbstract {
    * @throws ElasticsearchException ElasticsearchException
    * @throws IOException            IOException
    */
-  public void genSessionByRefererInSequential(int timeThres)
-      throws ElasticsearchException, IOException {
+  public void genSessionByRefererInSequential(int timeThres) throws ElasticsearchException, IOException {
 
     Terms users = this.getUserTerms(this.cleanupType);
 
@@ -137,8 +132,7 @@ public class SessionGenerator extends LogAbstract {
     LOG.info("Initial session count: {}", Integer.toString(sessionCount));
   }
 
-  public void combineShortSessionsInSequential(int timeThres)
-      throws ElasticsearchException, IOException {
+  public void combineShortSessionsInSequential(int timeThres) throws ElasticsearchException, IOException {
 
     Terms users = this.getUserTerms(this.cleanupType);
     for (Terms.Bucket entry : users.getBuckets()) {
@@ -160,16 +154,13 @@ public class SessionGenerator extends LogAbstract {
     BoolQueryBuilder filterAll = new BoolQueryBuilder();
     filterAll.must(QueryBuilders.termQuery("IP", ip));
 
-    SearchResponse scrollResp = es.getClient().prepareSearch(logIndex)
-        .setTypes(this.cleanupType).setScroll(new TimeValue(60000))
-        .setQuery(filterAll).setSize(100).execute().actionGet();
+    SearchResponse scrollResp = es.getClient().prepareSearch(logIndex).setTypes(this.cleanupType).setScroll(new TimeValue(60000)).setQuery(filterAll).setSize(100).execute().actionGet();
     while (true) {
       for (SearchHit hit : scrollResp.getHits().getHits()) {
         update(es, logIndex, cleanupType, hit.getId(), "SessionID", "invalid");
       }
 
-      scrollResp = es.getClient().prepareSearchScroll(scrollResp.getScrollId())
-          .setScroll(new TimeValue(600000)).execute().actionGet();
+      scrollResp = es.getClient().prepareSearchScroll(scrollResp.getScrollId()).setScroll(new TimeValue(600000)).execute().actionGet();
       if (scrollResp.getHits().getHits().length == 0) {
         break;
       }
@@ -188,57 +179,51 @@ public class SessionGenerator extends LogAbstract {
    * @throws ElasticsearchException
    * @throws IOException
    */
-  private void update(ESDriver es, String index, String type, String id,
-      String field1, Object value1) throws IOException {
-    UpdateRequest ur = new UpdateRequest(index, type, id)
-        .doc(jsonBuilder().startObject().field(field1, value1).endObject());
+  private void update(ESDriver es, String index, String type, String id, String field1, Object value1) throws IOException {
+    UpdateRequest ur = new UpdateRequest(index, type, id).doc(jsonBuilder().startObject().field(field1, value1).endObject());
     es.getBulkProcessor().add(ur);
   }
 
-  public void genSessionByRefererInParallel(int timeThres)
-      throws InterruptedException, IOException {
+  public void genSessionByRefererInParallel(int timeThres) throws InterruptedException, IOException {
 
     JavaRDD<String> userRDD = getUserRDD(this.cleanupType);
 
     int sessionCount = 0;
-    sessionCount = userRDD
-        .mapPartitions(new FlatMapFunction<Iterator<String>, Integer>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+    sessionCount = userRDD.mapPartitions(new FlatMapFunction<Iterator<String>, Integer>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Iterator<Integer> call(Iterator<String> arg0)
-              throws Exception {
-            ESDriver tmpES = new ESDriver(props);
-            tmpES.createBulkProcessor();
-            List<Integer> sessionNums = new ArrayList<>();
-            while (arg0.hasNext()) {
-              String s = arg0.next();
-              Integer sessionNum = genSessionByReferer(tmpES, s, timeThres);
-              sessionNums.add(sessionNum);
-            }
-            tmpES.destroyBulkProcessor();
-            return sessionNums.iterator();
-          }
-        }).reduce(new Function2<Integer, Integer, Integer>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+      @Override
+      public Iterator<Integer> call(Iterator<String> arg0) throws Exception {
+        ESDriver tmpES = new ESDriver(props);
+        tmpES.createBulkProcessor();
+        List<Integer> sessionNums = new ArrayList<>();
+        while (arg0.hasNext()) {
+          String s = arg0.next();
+          Integer sessionNum = genSessionByReferer(tmpES, s, timeThres);
+          sessionNums.add(sessionNum);
+        }
+        tmpES.destroyBulkProcessor();
+        return sessionNums.iterator();
+      }
+    }).reduce(new Function2<Integer, Integer, Integer>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Integer call(Integer a, Integer b) {
-            return a + b;
-          }
-        });
+      @Override
+      public Integer call(Integer a, Integer b) {
+        return a + b;
+      }
+    });
 
     LOG.info("Initial Session count: {}", Integer.toString(sessionCount));
   }
 
-  public int genSessionByReferer(ESDriver es, String user, int timeThres)
-      throws ElasticsearchException, IOException {
+  public int genSessionByReferer(ESDriver es, String user, int timeThres) throws ElasticsearchException, IOException {
 
     String startTime = null;
     int sessionCountIn = 0;
@@ -246,9 +231,7 @@ public class SessionGenerator extends LogAbstract {
     BoolQueryBuilder filterSearch = new BoolQueryBuilder();
     filterSearch.must(QueryBuilders.termQuery("IP", user));
 
-    SearchResponse scrollResp = es.getClient().prepareSearch(logIndex)
-        .setTypes(this.cleanupType).setScroll(new TimeValue(60000))
-        .setQuery(filterSearch).addSort("Time", SortOrder.ASC).setSize(100)
+    SearchResponse scrollResp = es.getClient().prepareSearch(logIndex).setTypes(this.cleanupType).setScroll(new TimeValue(60000)).setQuery(filterSearch).addSort("Time", SortOrder.ASC).setSize(100)
         .execute().actionGet();
 
     Map<String, Map<String, DateTime>> sessionReqs = new HashMap<>();
@@ -271,28 +254,22 @@ public class SessionGenerator extends LogAbstract {
         id = hit.getId();
 
         if ("PO.DAAC".equals(logType)) {
-          if ("-".equals(referer) || referer.equals(indexUrl) || !referer
-              .contains(indexUrl)) {
+          if ("-".equals(referer) || referer.equals(indexUrl) || !referer.contains(indexUrl)) {
             sessionCountIn++;
-            sessionReqs.put(ip + "@" + sessionCountIn,
-                new HashMap<String, DateTime>());
+            sessionReqs.put(ip + "@" + sessionCountIn, new HashMap<String, DateTime>());
             sessionReqs.get(ip + "@" + sessionCountIn).put(request, time);
 
-            update(es, logIndex, this.cleanupType, id, "SessionID",
-                ip + "@" + sessionCountIn);
+            update(es, logIndex, this.cleanupType, id, "SessionID", ip + "@" + sessionCountIn);
 
           } else {
             int count = sessionCountIn;
             int rollbackNum = 0;
             while (true) {
-              Map<String, DateTime> requests = sessionReqs
-                  .get(ip + "@" + count);
+              Map<String, DateTime> requests = sessionReqs.get(ip + "@" + count);
               if (requests == null) {
-                sessionReqs
-                    .put(ip + "@" + count, new HashMap<String, DateTime>());
+                sessionReqs.put(ip + "@" + count, new HashMap<String, DateTime>());
                 sessionReqs.get(ip + "@" + count).put(request, time);
-                update(es, logIndex, this.cleanupType, id, "SessionID",
-                    ip + "@" + count);
+                update(es, logIndex, this.cleanupType, id, "SessionID", ip + "@" + count);
 
                 break;
               }
@@ -305,20 +282,14 @@ public class SessionGenerator extends LogAbstract {
                   bFindRefer = true;
                   // threshold,if time interval > 10*
                   // click num, start a new session
-                  if (Math.abs(
-                      Seconds.secondsBetween(requests.get(keys.get(i)), time)
-                          .getSeconds()) < timeThres * rollbackNum) {
+                  if (Math.abs(Seconds.secondsBetween(requests.get(keys.get(i)), time).getSeconds()) < timeThres * rollbackNum) {
                     sessionReqs.get(ip + "@" + count).put(request, time);
-                    update(es, logIndex, this.cleanupType, id, "SessionID",
-                        ip + "@" + count);
+                    update(es, logIndex, this.cleanupType, id, "SessionID", ip + "@" + count);
                   } else {
                     sessionCountIn++;
-                    sessionReqs.put(ip + "@" + sessionCountIn,
-                        new HashMap<String, DateTime>());
-                    sessionReqs.get(ip + "@" + sessionCountIn)
-                        .put(request, time);
-                    update(es, logIndex, this.cleanupType, id, "SessionID",
-                        ip + "@" + sessionCountIn);
+                    sessionReqs.put(ip + "@" + sessionCountIn, new HashMap<String, DateTime>());
+                    sessionReqs.get(ip + "@" + sessionCountIn).put(request, time);
+                    update(es, logIndex, this.cleanupType, id, "SessionID", ip + "@" + sessionCountIn);
                   }
 
                   break;
@@ -333,12 +304,9 @@ public class SessionGenerator extends LogAbstract {
               if (count < 0) {
                 sessionCountIn++;
 
-                sessionReqs.put(ip + "@" + sessionCountIn,
-                    new HashMap<String, DateTime>());
+                sessionReqs.put(ip + "@" + sessionCountIn, new HashMap<String, DateTime>());
                 sessionReqs.get(ip + "@" + sessionCountIn).put(request, time);
-                update(es, props.getProperty(MudrodConstants.ES_INDEX_NAME),
-                    this.cleanupType, id, "SessionID",
-                    ip + "@" + sessionCountIn);
+                update(es, props.getProperty(MudrodConstants.ES_INDEX_NAME), this.cleanupType, id, "SessionID", ip + "@" + sessionCountIn);
 
                 break;
               }
@@ -347,37 +315,29 @@ public class SessionGenerator extends LogAbstract {
         } else if ("ftp".equals(logType)) {
 
           // may affect computation efficiency
-          Map<String, DateTime> requests = sessionReqs
-              .get(ip + "@" + sessionCountIn);
+          Map<String, DateTime> requests = sessionReqs.get(ip + "@" + sessionCountIn);
           if (requests == null) {
-            sessionReqs.put(ip + "@" + sessionCountIn,
-                new HashMap<String, DateTime>());
+            sessionReqs.put(ip + "@" + sessionCountIn, new HashMap<String, DateTime>());
           } else {
             ArrayList<String> keys = new ArrayList<>(requests.keySet());
             int size = keys.size();
-            if (Math.abs(
-                Seconds.secondsBetween(requests.get(keys.get(size - 1)), time)
-                    .getSeconds()) > timeThres) {
+            if (Math.abs(Seconds.secondsBetween(requests.get(keys.get(size - 1)), time).getSeconds()) > timeThres) {
               sessionCountIn += 1;
-              sessionReqs.put(ip + "@" + sessionCountIn,
-                  new HashMap<String, DateTime>());
+              sessionReqs.put(ip + "@" + sessionCountIn, new HashMap<String, DateTime>());
             }
           }
           sessionReqs.get(ip + "@" + sessionCountIn).put(request, time);
-          update(es, logIndex, this.cleanupType, id, "SessionID",
-              ip + "@" + sessionCountIn);
+          update(es, logIndex, this.cleanupType, id, "SessionID", ip + "@" + sessionCountIn);
         }
       }
 
-      scrollResp = es.getClient().prepareSearchScroll(scrollResp.getScrollId())
-          .setScroll(new TimeValue(600000)).execute().actionGet();
+      scrollResp = es.getClient().prepareSearchScroll(scrollResp.getScrollId()).setScroll(new TimeValue(600000)).execute().actionGet();
     }
 
     return sessionCountIn;
   }
 
-  public void combineShortSessionsInParallel(int timeThres)
-      throws InterruptedException, IOException {
+  public void combineShortSessionsInParallel(int timeThres) throws InterruptedException, IOException {
 
     JavaRDD<String> userRDD = getUserRDD(this.cleanupType);
 
@@ -400,8 +360,7 @@ public class SessionGenerator extends LogAbstract {
     });
   }
 
-  public void combineShortSessions(ESDriver es, String user, int timeThres)
-      throws ElasticsearchException, IOException {
+  public void combineShortSessions(ESDriver es, String user, int timeThres) throws ElasticsearchException, IOException {
 
     BoolQueryBuilder filterSearch = new BoolQueryBuilder();
     filterSearch.must(QueryBuilders.termQuery("IP", user));
@@ -416,11 +375,8 @@ public class SessionGenerator extends LogAbstract {
     }
 
     BoolQueryBuilder filterCheck = new BoolQueryBuilder();
-    filterCheck.must(QueryBuilders.termQuery("IP", user))
-        .must(QueryBuilders.termQuery("Referer", "-"));
-    SearchResponse checkReferer = es.getClient().prepareSearch(logIndex)
-        .setTypes(this.cleanupType).setScroll(new TimeValue(60000))
-        .setQuery(filterCheck).setSize(0).execute().actionGet();
+    filterCheck.must(QueryBuilders.termQuery("IP", user)).must(QueryBuilders.termQuery("Referer", "-"));
+    SearchResponse checkReferer = es.getClient().prepareSearch(logIndex).setTypes(this.cleanupType).setScroll(new TimeValue(60000)).setQuery(filterCheck).setSize(0).execute().actionGet();
 
     long numInvalid = checkReferer.getHits().getTotalHits();
     double invalidRate = numInvalid / docCount;
@@ -430,21 +386,16 @@ public class SessionGenerator extends LogAbstract {
       return;
     }
 
-    StatsAggregationBuilder statsAgg = AggregationBuilders.stats("Stats")
-        .field("Time");
-    SearchResponse srSession = es.getClient().prepareSearch(logIndex)
-        .setTypes(this.cleanupType).setScroll(new TimeValue(60000))
-        .setQuery(filterSearch).addAggregation(
-            AggregationBuilders.terms("Sessions").field("SessionID")
-                .size(docCount).subAggregation(statsAgg)).execute().actionGet();
+    StatsAggregationBuilder statsAgg = AggregationBuilders.stats("Stats").field("Time");
+    SearchResponse srSession = es.getClient().prepareSearch(logIndex).setTypes(this.cleanupType).setScroll(new TimeValue(60000)).setQuery(filterSearch)
+        .addAggregation(AggregationBuilders.terms("Sessions").field("SessionID").size(docCount).subAggregation(statsAgg)).execute().actionGet();
 
     Terms sessions = srSession.getAggregations().get("Sessions");
 
     List<Session> sessionList = new ArrayList<>();
     for (Terms.Bucket session : sessions.getBuckets()) {
       Stats agg = session.getAggregations().get("Stats");
-      Session sess = new Session(props, es, agg.getMinAsString(),
-          agg.getMaxAsString(), session.getKey().toString());
+      Session sess = new Session(props, es, agg.getMinAsString(), agg.getMaxAsString(), session.getKey().toString());
       sessionList.add(sess);
     }
 
@@ -457,35 +408,26 @@ public class SessionGenerator extends LogAbstract {
     for (Session s : sessionList) {
       current = s.getEndTime();
       if (last != null) {
-        if (Seconds
-            .secondsBetween(fmt.parseDateTime(last), fmt.parseDateTime(current))
-            .getSeconds() < timeThres) {
+        if (Seconds.secondsBetween(fmt.parseDateTime(last), fmt.parseDateTime(current)).getSeconds() < timeThres) {
           if (lastnewID == null) {
             s.setNewID(lastoldID);
           } else {
             s.setNewID(lastnewID);
           }
 
-          QueryBuilder fs = QueryBuilders.boolQuery()
-              .filter(QueryBuilders.termQuery("SessionID", s.getID()));
+          QueryBuilder fs = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("SessionID", s.getID()));
 
-          SearchResponse scrollResp = es.getClient().prepareSearch(logIndex)
-              .setTypes(this.cleanupType).setScroll(new TimeValue(60000))
-              .setQuery(fs).setSize(100).execute().actionGet();
+          SearchResponse scrollResp = es.getClient().prepareSearch(logIndex).setTypes(this.cleanupType).setScroll(new TimeValue(60000)).setQuery(fs).setSize(100).execute().actionGet();
           while (true) {
             for (SearchHit hit : scrollResp.getHits().getHits()) {
               if (lastnewID == null) {
-                update(es, logIndex, this.cleanupType, hit.getId(), "SessionID",
-                    lastoldID);
+                update(es, logIndex, this.cleanupType, hit.getId(), "SessionID", lastoldID);
               } else {
-                update(es, logIndex, this.cleanupType, hit.getId(), "SessionID",
-                    lastnewID);
+                update(es, logIndex, this.cleanupType, hit.getId(), "SessionID", lastnewID);
               }
             }
 
-            scrollResp = es.getClient()
-                .prepareSearchScroll(scrollResp.getScrollId())
-                .setScroll(new TimeValue(600000)).execute().actionGet();
+            scrollResp = es.getClient().prepareSearchScroll(scrollResp.getScrollId()).setScroll(new TimeValue(600000)).execute().actionGet();
             if (scrollResp.getHits().getHits().length == 0) {
               break;
             }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/process/ClickStreamAnalyzer.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/process/ClickStreamAnalyzer.java
@@ -35,8 +35,7 @@ public class ClickStreamAnalyzer extends DiscoveryStepAbstract {
    */
   private static final long serialVersionUID = 1L;
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(ClickStreamAnalyzer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ClickStreamAnalyzer.class);
 
   public ClickStreamAnalyzer(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
@@ -51,16 +50,11 @@ public class ClickStreamAnalyzer extends DiscoveryStepAbstract {
     startTime = System.currentTimeMillis();
     try {
       SVDAnalyzer svd = new SVDAnalyzer(props, es, spark);
-      svd.getSVDMatrix(props.getProperty("clickstreamMatrix"),
-          Integer.parseInt(props.getProperty("clickstreamSVDDimension")),
-          props.getProperty("clickstreamSVDMatrix_tmp"));
-      List<LinkageTriple> tripleList = svd
-          .calTermSimfromMatrix(props.getProperty("clickstreamSVDMatrix_tmp"));
-      svd.saveToES(tripleList, props.getProperty("indexName"),
-          props.getProperty("clickStreamLinkageType"));
+      svd.getSVDMatrix(props.getProperty("clickstreamMatrix"), Integer.parseInt(props.getProperty("clickstreamSVDDimension")), props.getProperty("clickstreamSVDMatrix_tmp"));
+      List<LinkageTriple> tripleList = svd.calTermSimfromMatrix(props.getProperty("clickstreamSVDMatrix_tmp"));
+      svd.saveToES(tripleList, props.getProperty("indexName"), props.getProperty("clickStreamLinkageType"));
     } catch (Exception e) {
-      LOG.error("Encountered an error during execution of ClickStreamAnalyzer.",
-          e);
+      LOG.error("Encountered an error during execution of ClickStreamAnalyzer.", e);
     }
 
     //Store click stream in ES for the ranking use
@@ -69,8 +63,7 @@ public class ClickStreamAnalyzer extends DiscoveryStepAbstract {
 
     endTime = System.currentTimeMillis();
     es.refreshIndex();
-    LOG.info("ClickStreamAnalyzer complete. Time elapsed: {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("ClickStreamAnalyzer complete. Time elapsed: {}s", (endTime - startTime) / 1000);
     return null;
   }
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/process/UserHistoryAnalyzer.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/process/UserHistoryAnalyzer.java
@@ -33,8 +33,7 @@ public class UserHistoryAnalyzer extends DiscoveryStepAbstract {
    *
    */
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory
-      .getLogger(UserHistoryAnalyzer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(UserHistoryAnalyzer.class);
 
   public UserHistoryAnalyzer(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
@@ -49,15 +48,12 @@ public class UserHistoryAnalyzer extends DiscoveryStepAbstract {
     startTime = System.currentTimeMillis();
 
     SemanticAnalyzer sa = new SemanticAnalyzer(props, es, spark);
-    List<LinkageTriple> tripleList = sa
-        .calTermSimfromMatrix(props.getProperty("userHistoryMatrix"));
-    sa.saveToES(tripleList, props.getProperty("indexName"),
-        props.getProperty("userHistoryLinkageType"));
+    List<LinkageTriple> tripleList = sa.calTermSimfromMatrix(props.getProperty("userHistoryMatrix"));
+    sa.saveToES(tripleList, props.getProperty("indexName"), props.getProperty("userHistoryLinkageType"));
 
     endTime = System.currentTimeMillis();
     es.refreshIndex();
-    LOG.info("UserHistoryAnalyzer complete. Time elapsed: {}s",
-        (endTime - startTime) / 1000);
+    LOG.info("UserHistoryAnalyzer complete. Time elapsed: {}s", (endTime - startTime) / 1000);
     return null;
   }
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/ApacheAccessLog.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/ApacheAccessLog.java
@@ -56,8 +56,7 @@ public class ApacheAccessLog extends WebLog implements Serializable {
 
   }
 
-  public static String parseFromLogLine(String log)
-      throws IOException, ParseException {
+  public static String parseFromLogLine(String log) throws IOException, ParseException {
 
     String logEntryPattern = "^([\\d.]+) (\\S+) (\\S+) \\[([\\w:/]+\\s[+\\-]\\d{4})\\] \"(.+?)\" (\\d{3}) (\\d+|-) \"((?:[^\"]|\")+)\" \"([^\"]+)\"";
     final int NUM_FIELDS = 9;
@@ -89,9 +88,7 @@ public class ApacheAccessLog extends WebLog implements Serializable {
     } else {
 
       boolean tag = false;
-      String[] mimeTypes = { ".js", ".css", ".jpg", ".png", ".ico",
-          "image_captcha", "autocomplete", ".gif", "/alldata/", "/api/",
-          "get / http/1.1", ".jpeg", "/ws/" };
+      String[] mimeTypes = { ".js", ".css", ".jpg", ".png", ".ico", "image_captcha", "autocomplete", ".gif", "/alldata/", "/api/", "get / http/1.1", ".jpeg", "/ws/" };
       for (int i = 0; i < mimeTypes.length; i++) {
         if (request.contains(mimeTypes[i])) {
           tag = true;
@@ -108,8 +105,7 @@ public class ApacheAccessLog extends WebLog implements Serializable {
         accesslog.Bytes = Double.parseDouble(bytes);
         accesslog.Referer = matcher.group(8);
         accesslog.Browser = matcher.group(9);
-        SimpleDateFormat df = new SimpleDateFormat(
-            "yyyy-MM-dd'T'HH:mm:ss.sss'Z'");
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss'Z'");
         accesslog.Time = df.format(date);
 
         Gson gson = new Gson();

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/ClickStream.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/ClickStream.java
@@ -144,8 +144,7 @@ public class ClickStream implements Serializable {
    */
   @Override
   public String toString() {
-    return "query:" + keywords + "|| view dataset:" + viewDataset
-        + "|| download Dataset:" + downloadDataset;
+    return "query:" + keywords + "|| view dataset:" + viewDataset + "|| download Dataset:" + downloadDataset;
   }
 
   /**

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/FtpLog.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/FtpLog.java
@@ -27,14 +27,11 @@ import java.util.Date;
  */
 public class FtpLog extends WebLog implements Serializable {
 
-  public static String parseFromLogLine(String log)
-      throws IOException, ParseException {
+  public static String parseFromLogLine(String log) throws IOException, ParseException {
 
     String ip = log.split(" +")[6];
 
-    String time =
-        log.split(" +")[1] + ":" + log.split(" +")[2] + ":" + log.split(" +")[3]
-            + ":" + log.split(" +")[4];
+    String time = log.split(" +")[1] + ":" + log.split(" +")[2] + ":" + log.split(" +")[3] + ":" + log.split(" +")[4];
 
     time = SwithtoNum(time);
     SimpleDateFormat formatter = new SimpleDateFormat("MM:dd:HH:mm:ss:yyyy");
@@ -50,8 +47,7 @@ public class FtpLog extends WebLog implements Serializable {
       ftplog.Request = request;
       ftplog.Bytes = Double.parseDouble(bytes);
 
-      SimpleDateFormat df = new SimpleDateFormat(
-          "yyyy-MM-dd'T'HH:mm:ss.sss'Z'");
+      SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss'Z'");
       ftplog.Time = df.format(date);
       // ftplog.Time = date;
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/GeoIp.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/GeoIp.java
@@ -38,10 +38,8 @@ public class GeoIp {
     JsonObject responseObject = jobSon.getAsJsonObject();
 
     Coordinates co = new Coordinates();
-    String lon = responseObject.get("geobyteslongitude").toString()
-        .replace("\"", "");
-    String lat = responseObject.get("geobyteslatitude").toString()
-        .replace("\"", "");
+    String lon = responseObject.get("geobyteslongitude").toString().replace("\"", "");
+    String lat = responseObject.get("geobyteslatitude").toString().replace("\"", "");
     co.latlon = lat + "," + lon;
     return co;
   }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/RankingTrainData.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/RankingTrainData.java
@@ -31,8 +31,7 @@ public class RankingTrainData implements Serializable {
    * @param highRankDataset the dataset name for the highest ranked dataset
    * @param lowRankDataset  the dataset name for the lowest ranked dataset
    */
-  public RankingTrainData(String query, String highRankDataset,
-      String lowRankDataset) {
+  public RankingTrainData(String query, String highRankDataset, String lowRankDataset) {
     this.query = query;
     this.highRankDataset = highRankDataset;
     this.lowRankDataset = lowRankDataset;
@@ -120,8 +119,7 @@ public class RankingTrainData implements Serializable {
    */
   @Override
   public String toString() {
-    return "query:" + query + "|| highRankDataset:" + highRankDataset
-        + "|| lowRankDataset:" + lowRankDataset;
+    return "query:" + query + "|| highRankDataset:" + highRankDataset + "|| lowRankDataset:" + lowRankDataset;
   }
 
   /**

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/RequestUrl.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/RequestUrl.java
@@ -137,17 +137,14 @@ public class RequestUrl extends MudrodAbstract {
       try {
         keyword = mapRequest.get("search");
 
-        keyword = URLDecoder
-            .decode(keyword.replaceAll("%(?![0-9a-fA-F]{2})", "%25"), "UTF-8");
-        if (keyword.contains("%2b") || keyword.contains("%20") || keyword
-            .contains("%25")) {
+        keyword = URLDecoder.decode(keyword.replaceAll("%(?![0-9a-fA-F]{2})", "%25"), "UTF-8");
+        if (keyword.contains("%2b") || keyword.contains("%20") || keyword.contains("%25")) {
           keyword = keyword.replace("%2b", " ");
           keyword = keyword.replace("%20", " ");
           keyword = keyword.replace("%25", " ");
         }
 
-        keyword = keyword.replaceAll("[-+^:,*_\"]", " ").replace("\\", " ")
-            .replaceAll("\\s+", " ").trim();
+        keyword = keyword.replaceAll("[-+^:,*_\"]", " ").replace("\\", " ").replaceAll("\\s+", " ").trim();
 
       } catch (UnsupportedEncodingException e) {
         LOG.error(mapRequest.get("search"));
@@ -170,22 +167,17 @@ public class RequestUrl extends MudrodAbstract {
       int l = a < b ? a : b;
 
       for (int i = 0; i < l; i++) {
-        if (ids[i].equals("collections") || ids[i].equals("measurement")
-            || ids[i].equals("sensor") || ids[i].equals("platform") || ids[i]
-            .equals("variable") || ids[i].equals("spatialcoverage")) {
+        if (ids[i].equals("collections") || ids[i].equals("measurement") || ids[i].equals("sensor") || ids[i].equals("platform") || ids[i].equals("variable") || ids[i].equals("spatialcoverage")) {
           try {
             values[i] = values[i].replaceAll("%(?![0-9a-fA-F]{2})", "%25");
-            if (!URLDecoder.decode(values[i], "UTF-8").equals(keyword)
-                && !URLDecoder.decode(values[i], "UTF-8").equals("")) {
+            if (!URLDecoder.decode(values[i], "UTF-8").equals(keyword) && !URLDecoder.decode(values[i], "UTF-8").equals("")) {
               String item = URLDecoder.decode(values[i], "UTF-8").trim();
-              if (item.contains("%2b") || item.contains("%20") || item
-                  .contains("%25")) {
+              if (item.contains("%2b") || item.contains("%20") || item.contains("%25")) {
                 item = item.replace("%2b", " ");
                 item = item.replace("%20", " ");
                 item = item.replace("%25", " ");
               }
-              item = item.replaceAll("[-+^:,*_\"]", " ").replace("\\", " ")
-                  .replaceAll("\\s+", " ").trim();
+              item = item.replaceAll("[-+^:,*_\"]", " ").replace("\\", " ").replaceAll("\\s+", " ").trim();
               info.add(item);
             }
           } catch (Exception e) {
@@ -226,16 +218,13 @@ public class RequestUrl extends MudrodAbstract {
       try {
         keyword = mapRequest.get("search");
 
-        keyword = URLDecoder
-            .decode(keyword.replaceAll("%(?![0-9a-fA-F]{2})", "%25"), "UTF-8");
-        if (keyword.contains("%2b") || keyword.contains("%20") || keyword
-            .contains("%25")) {
+        keyword = URLDecoder.decode(keyword.replaceAll("%(?![0-9a-fA-F]{2})", "%25"), "UTF-8");
+        if (keyword.contains("%2b") || keyword.contains("%20") || keyword.contains("%25")) {
           keyword = keyword.replace("%2b", " ");
           keyword = keyword.replace("%20", " ");
           keyword = keyword.replace("%25", " ");
         }
-        keyword = keyword.replaceAll("[-+^:,*_\"]", " ").replace("\\", " ")
-            .replaceAll("\\s+", " ").trim();
+        keyword = keyword.replaceAll("[-+^:,*_\"]", " ").replace("\\", " ").replaceAll("\\s+", " ").trim();
       } catch (UnsupportedEncodingException e) {
         LOG.error(mapRequest.get("search"));
         e.printStackTrace();
@@ -252,8 +241,7 @@ public class RequestUrl extends MudrodAbstract {
    * @return filter facet key pair map
    * @throws UnsupportedEncodingException UnsupportedEncodingException
    */
-  public static Map<String, String> getFilterInfo(String url)
-      throws UnsupportedEncodingException {
+  public static Map<String, String> getFilterInfo(String url) throws UnsupportedEncodingException {
     List<String> info = new ArrayList<>();
     Map<String, String> filterValues = new HashMap<>();
 
@@ -263,16 +251,13 @@ public class RequestUrl extends MudrodAbstract {
       try {
         keyword = mapRequest.get("search");
 
-        keyword = URLDecoder
-            .decode(keyword.replaceAll("%(?![0-9a-fA-F]{2})", "%25"), "UTF-8");
-        if (keyword.contains("%2b") || keyword.contains("%20") || keyword
-            .contains("%25")) {
+        keyword = URLDecoder.decode(keyword.replaceAll("%(?![0-9a-fA-F]{2})", "%25"), "UTF-8");
+        if (keyword.contains("%2b") || keyword.contains("%20") || keyword.contains("%25")) {
           keyword = keyword.replace("%2b", " ");
           keyword = keyword.replace("%20", " ");
           keyword = keyword.replace("%25", " ");
         }
-        keyword = keyword.replaceAll("[-+^:,*_\"]", " ").replace("\\", " ")
-            .replaceAll("\\s+", " ").trim();
+        keyword = keyword.replaceAll("[-+^:,*_\"]", " ").replace("\\", " ").replaceAll("\\s+", " ").trim();
 
       } catch (UnsupportedEncodingException e) {
         LOG.error(mapRequest.get("search"));
@@ -297,17 +282,14 @@ public class RequestUrl extends MudrodAbstract {
       for (int i = 0; i < l; i++) {
         try {
           values[i] = values[i].replaceAll("%(?![0-9a-fA-F]{2})", "%25");
-          if (!URLDecoder.decode(values[i], "UTF-8").equals(keyword)
-              && !URLDecoder.decode(values[i], "UTF-8").equals("")) {
+          if (!URLDecoder.decode(values[i], "UTF-8").equals(keyword) && !URLDecoder.decode(values[i], "UTF-8").equals("")) {
             String item = URLDecoder.decode(values[i], "UTF-8").trim();
-            if (item.contains("%2b") || item.contains("%20") || item
-                .contains("%25")) {
+            if (item.contains("%2b") || item.contains("%20") || item.contains("%25")) {
               item = item.replace("%2b", " ");
               item = item.replace("%20", " ");
               item = item.replace("%25", " ");
             }
-            item = item.replaceAll("[-+^:,*_\"]", " ").replace("\\", " ")
-                .replaceAll("\\s+", " ").trim();
+            item = item.replaceAll("[-+^:,*_\"]", " ").replace("\\", " ").replaceAll("\\s+", " ").trim();
             filterValues.put(ids[i], item);
           }
         } catch (Exception e) {
@@ -319,9 +301,7 @@ public class RequestUrl extends MudrodAbstract {
 
     if (mapRequest.get("temporalsearch") != null) {
       String temporalsearch = mapRequest.get("temporalsearch");
-      temporalsearch = URLDecoder
-          .decode(temporalsearch.replaceAll("%(?![0-9a-fA-F]{2})", "%25"),
-              "UTF-8");
+      temporalsearch = URLDecoder.decode(temporalsearch.replaceAll("%(?![0-9a-fA-F]{2})", "%25"), "UTF-8");
 
       filterValues.put("temporalsearch", temporalsearch);
     }

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/Session.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/Session.java
@@ -63,8 +63,7 @@ public class Session /*extends MudrodAbstract*/ implements Comparable<Session> {
    * @param end   end time of session
    * @param id    session ID
    */
-  public Session(Properties props, ESDriver es, String start, String end,
-      String id) {
+  public Session(Properties props, ESDriver es, String start, String end, String id) {
     this.start = start;
     this.end = end;
     this.id = id;
@@ -140,9 +139,7 @@ public class Session /*extends MudrodAbstract*/ implements Comparable<Session> {
     fmt.parseDateTime(this.end);
     fmt.parseDateTime(o.end);
     // ascending order
-    return Seconds
-        .secondsBetween(fmt.parseDateTime(o.end), fmt.parseDateTime(this.end))
-        .getSeconds();
+    return Seconds.secondsBetween(fmt.parseDateTime(o.end), fmt.parseDateTime(this.end)).getSeconds();
 
   }
 
@@ -155,8 +152,7 @@ public class Session /*extends MudrodAbstract*/ implements Comparable<Session> {
    * @param sessionID:   Session ID
    * @return Session details in Json format
    */
-  public JsonObject getSessionDetail(String indexName, String cleanuptype,
-      String sessionID) {
+  public JsonObject getSessionDetail(String indexName, String cleanuptype, String sessionID) {
     JsonObject sessionResults = new JsonObject();
     // for session tree
     SessionTree tree = null;
@@ -185,8 +181,7 @@ public class Session /*extends MudrodAbstract*/ implements Comparable<Session> {
    * @return Click stram data list
    * {@link ClickStream}
    */
-  public List<ClickStream> getClickStreamList(String indexName,
-      String cleanuptype, String sessionID) {
+  public List<ClickStream> getClickStreamList(String indexName, String cleanuptype, String sessionID) {
     SessionTree tree = null;
     try {
       tree = this.getSessionTree(indexName, cleanuptype, sessionID);
@@ -206,16 +201,12 @@ public class Session /*extends MudrodAbstract*/ implements Comparable<Session> {
    * @return an instance of session tree structure
    * @throws UnsupportedEncodingException UnsupportedEncodingException
    */
-  private SessionTree getSessionTree(String indexName, String cleanuptype,
-      String sessionID) throws UnsupportedEncodingException {
+  private SessionTree getSessionTree(String indexName, String cleanuptype, String sessionID) throws UnsupportedEncodingException {
 
-    SearchResponse response = es.getClient().prepareSearch(indexName)
-        .setTypes(cleanuptype)
-        .setQuery(QueryBuilders.termQuery("SessionID", sessionID)).setSize(100)
-        .addSort("Time", SortOrder.ASC).execute().actionGet();
+    SearchResponse response = es.getClient().prepareSearch(indexName).setTypes(cleanuptype).setQuery(QueryBuilders.termQuery("SessionID", sessionID)).setSize(100).addSort("Time", SortOrder.ASC)
+        .execute().actionGet();
 
-    SessionTree tree = new SessionTree(this.props, this.es, sessionID,
-        cleanuptype);
+    SessionTree tree = new SessionTree(this.props, this.es, sessionID, cleanuptype);
     int seq = 1;
     for (SearchHit hit : response.getHits().getHits()) {
       Map<String, Object> result = hit.getSource();
@@ -240,11 +231,8 @@ public class Session /*extends MudrodAbstract*/ implements Comparable<Session> {
    * @return all of these requests in JSON
    * @throws UnsupportedEncodingException UnsupportedEncodingException
    */
-  private JsonElement getRequests(String cleanuptype, String sessionID)
-      throws UnsupportedEncodingException {
-    SearchResponse response = es.getClient()
-        .prepareSearch(props.getProperty("indexName")).setTypes(cleanuptype)
-        .setQuery(QueryBuilders.termQuery("SessionID", sessionID)).setSize(100)
+  private JsonElement getRequests(String cleanuptype, String sessionID) throws UnsupportedEncodingException {
+    SearchResponse response = es.getClient().prepareSearch(props.getProperty("indexName")).setTypes(cleanuptype).setQuery(QueryBuilders.termQuery("SessionID", sessionID)).setSize(100)
         .addSort("Time", SortOrder.ASC).execute().actionGet();
     int size = response.getHits().getHits().length;
 
@@ -284,8 +272,7 @@ public class Session /*extends MudrodAbstract*/ implements Comparable<Session> {
    * @return Click stram data list
    * {@link ClickStream}
    */
-  public List<RankingTrainData> getRankingTrainData(String indexName,
-      String cleanuptype, String sessionID) {
+  public List<RankingTrainData> getRankingTrainData(String indexName, String cleanuptype, String sessionID) {
     SessionTree tree = null;
     try {
       tree = this.getSessionTree(indexName, cleanuptype, sessionID);

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/SessionExtractor.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/SessionExtractor.java
@@ -58,8 +58,7 @@ public class SessionExtractor implements Serializable {
    * @return clickstream list in JavaRDD format
    * {@link ClickStream}
    */
-  public JavaRDD<ClickStream> extractClickStreamFromES(Properties props,
-      ESDriver es, SparkDriver spark) {
+  public JavaRDD<ClickStream> extractClickStreamFromES(Properties props, ESDriver es, SparkDriver spark) {
 
     String processingType = props.getProperty("processingType");
     if (processingType.equals(MudrodConstants.SEQUENTIAL_PROCESS)) {
@@ -80,10 +79,8 @@ public class SessionExtractor implements Serializable {
    * @return clickstream list
    * {@link ClickStream}
    */
-  protected List<ClickStream> getClickStreamList(Properties props,
-      ESDriver es) {
-    List<String> logIndexList = es
-        .getIndexListWithPrefix(props.getProperty(MudrodConstants.LOG_INDEX));
+  protected List<ClickStream> getClickStreamList(Properties props, ESDriver es) {
+    List<String> logIndexList = es.getIndexListWithPrefix(props.getProperty(MudrodConstants.LOG_INDEX));
 
     List<ClickStream> result = new ArrayList<>();
     for (int n = 0; n < logIndexList.size(); n++) {
@@ -95,8 +92,7 @@ public class SessionExtractor implements Serializable {
         int sessionNum = sessionIdList.size();
         for (int i = 0; i < sessionNum; i++) {
           String[] sArr = sessionIdList.get(i).split(",");
-          List<ClickStream> datas = session
-              .getClickStreamList(sArr[1], sArr[2], sArr[0]);
+          List<ClickStream> datas = session.getClickStreamList(sArr[1], sArr[2], sArr[0]);
           result.addAll(datas);
         }
       } catch (Exception e) {
@@ -107,11 +103,9 @@ public class SessionExtractor implements Serializable {
     return result;
   }
 
-  protected JavaRDD<ClickStream> getClickStreamListInParallel(Properties props,
-      SparkDriver spark, ESDriver es) {
+  protected JavaRDD<ClickStream> getClickStreamListInParallel(Properties props, SparkDriver spark, ESDriver es) {
 
-    List<String> logIndexList = es
-        .getIndexListWithPrefix(props.getProperty(MudrodConstants.LOG_INDEX));
+    List<String> logIndexList = es.getIndexListWithPrefix(props.getProperty(MudrodConstants.LOG_INDEX));
 
     System.out.print(logIndexList.toString());
 
@@ -124,32 +118,29 @@ public class SessionExtractor implements Serializable {
 
     JavaRDD<String> sessionRDD = spark.sc.parallelize(sessionIdList, 16);
 
-    JavaRDD<ClickStream> ClickStreamRDD = sessionRDD
-        .mapPartitions(new FlatMapFunction<Iterator<String>, ClickStream>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+    JavaRDD<ClickStream> ClickStreamRDD = sessionRDD.mapPartitions(new FlatMapFunction<Iterator<String>, ClickStream>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Iterator<ClickStream> call(Iterator<String> arg0)
-              throws Exception {
-            ESDriver tmpES = new ESDriver(props);
-            tmpES.createBulkProcessor();
+      @Override
+      public Iterator<ClickStream> call(Iterator<String> arg0) throws Exception {
+        ESDriver tmpES = new ESDriver(props);
+        tmpES.createBulkProcessor();
 
-            Session session = new Session(props, tmpES);
-            List<ClickStream> clickstreams = new ArrayList<>();
-            while (arg0.hasNext()) {
-              String s = arg0.next();
-              String[] sArr = s.split(",");
-              List<ClickStream> clicks = session
-                  .getClickStreamList(sArr[1], sArr[2], sArr[0]);
-              clickstreams.addAll(clicks);
-            }
-            tmpES.destroyBulkProcessor();
-            return clickstreams.iterator();
-          }
-        });
+        Session session = new Session(props, tmpES);
+        List<ClickStream> clickstreams = new ArrayList<>();
+        while (arg0.hasNext()) {
+          String s = arg0.next();
+          String[] sArr = s.split(",");
+          List<ClickStream> clicks = session.getClickStreamList(sArr[1], sArr[2], sArr[0]);
+          clickstreams.addAll(clicks);
+        }
+        tmpES.destroyBulkProcessor();
+        return clickstreams.iterator();
+      }
+    });
 
     System.out.println("click stream number:" + ClickStreamRDD.count());
 
@@ -166,23 +157,20 @@ public class SessionExtractor implements Serializable {
    * @return clickstream list in JavaRDD format
    * {@link ClickStream}
    */
-  public JavaRDD<ClickStream> loadClickStremFromTxt(String clickthroughFile,
-      JavaSparkContext sc) {
-    return sc.textFile(clickthroughFile)
-        .flatMap(new FlatMapFunction<String, ClickStream>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+  public JavaRDD<ClickStream> loadClickStremFromTxt(String clickthroughFile, JavaSparkContext sc) {
+    return sc.textFile(clickthroughFile).flatMap(new FlatMapFunction<String, ClickStream>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @SuppressWarnings("unchecked")
-          @Override
-          public Iterator<ClickStream> call(String line) throws Exception {
-            List<ClickStream> clickthroughs = (List<ClickStream>) ClickStream
-                .parseFromTextLine(line);
-            return (Iterator<ClickStream>) clickthroughs;
-          }
-        });
+      @SuppressWarnings("unchecked")
+      @Override
+      public Iterator<ClickStream> call(String line) throws Exception {
+        List<ClickStream> clickthroughs = (List<ClickStream>) ClickStream.parseFromTextLine(line);
+        return (Iterator<ClickStream>) clickthroughs;
+      }
+    });
   }
 
   /**
@@ -192,49 +180,44 @@ public class SessionExtractor implements Serializable {
    * @param downloadWeight: weight of download behavior
    * @return JavaPairRDD, key is short name of data set, and values are queries
    */
-  public JavaPairRDD<String, List<String>> bulidDataQueryRDD(
-      JavaRDD<ClickStream> clickstreamRDD, int downloadWeight) {
-    return clickstreamRDD
-        .mapToPair(new PairFunction<ClickStream, String, List<String>>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+  public JavaPairRDD<String, List<String>> bulidDataQueryRDD(JavaRDD<ClickStream> clickstreamRDD, int downloadWeight) {
+    return clickstreamRDD.mapToPair(new PairFunction<ClickStream, String, List<String>>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Tuple2<String, List<String>> call(ClickStream click)
-              throws Exception {
-            List<String> query = new ArrayList<>();
-            // important! download behavior is given higher weights
-            // than viewing
-            // behavior
-            boolean download = click.isDownload();
-            int weight = 1;
-            if (download) {
-              weight = downloadWeight;
-            }
-            for (int i = 0; i < weight; i++) {
-              query.add(click.getKeyWords());
-            }
+      @Override
+      public Tuple2<String, List<String>> call(ClickStream click) throws Exception {
+        List<String> query = new ArrayList<>();
+        // important! download behavior is given higher weights
+        // than viewing
+        // behavior
+        boolean download = click.isDownload();
+        int weight = 1;
+        if (download) {
+          weight = downloadWeight;
+        }
+        for (int i = 0; i < weight; i++) {
+          query.add(click.getKeyWords());
+        }
 
-            return new Tuple2<>(click.getViewDataset(), query);
-          }
-        })
-        .reduceByKey(new Function2<List<String>, List<String>, List<String>>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+        return new Tuple2<>(click.getViewDataset(), query);
+      }
+    }).reduceByKey(new Function2<List<String>, List<String>, List<String>>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public List<String> call(List<String> v1, List<String> v2)
-              throws Exception {
-            List<String> list = new ArrayList<>();
-            list.addAll(v1);
-            list.addAll(v2);
-            return list;
-          }
-        });
+      @Override
+      public List<String> call(List<String> v1, List<String> v2) throws Exception {
+        List<String> list = new ArrayList<>();
+        list.addAll(v1);
+        list.addAll(v2);
+        return list;
+      }
+    });
   }
 
   /**
@@ -245,18 +228,13 @@ public class SessionExtractor implements Serializable {
    * @param logIndex a log index name
    * @return list of session names
    */
-  protected List<String> getSessions(Properties props, ESDriver es,
-      String logIndex) {
+  protected List<String> getSessions(Properties props, ESDriver es, String logIndex) {
 
-    String cleanupPrefix = props
-        .getProperty(MudrodConstants.CLEANUP_TYPE_PREFIX);
-    String sessionStatPrefix = props
-        .getProperty(MudrodConstants.SESSION_STATS_PREFIX);
+    String cleanupPrefix = props.getProperty(MudrodConstants.CLEANUP_TYPE_PREFIX);
+    String sessionStatPrefix = props.getProperty(MudrodConstants.SESSION_STATS_PREFIX);
 
     List<String> sessions = new ArrayList<>();
-    SearchResponse scrollResp = es.getClient().prepareSearch(logIndex)
-        .setTypes(sessionStatPrefix).setScroll(new TimeValue(60000))
-        .setQuery(QueryBuilders.matchAllQuery()).setSize(100).execute()
+    SearchResponse scrollResp = es.getClient().prepareSearch(logIndex).setTypes(sessionStatPrefix).setScroll(new TimeValue(60000)).setQuery(QueryBuilders.matchAllQuery()).setSize(100).execute()
         .actionGet();
     while (true) {
       for (SearchHit hit : scrollResp.getHits().getHits()) {
@@ -265,8 +243,7 @@ public class SessionExtractor implements Serializable {
         sessions.add(sessionID + "," + logIndex + "," + cleanupPrefix);
       }
 
-      scrollResp = es.getClient().prepareSearchScroll(scrollResp.getScrollId())
-          .setScroll(new TimeValue(600000)).execute().actionGet();
+      scrollResp = es.getClient().prepareSearchScroll(scrollResp.getScrollId()).setScroll(new TimeValue(600000)).execute().actionGet();
       if (scrollResp.getHits().getHits().length == 0) {
         break;
       }
@@ -275,139 +252,123 @@ public class SessionExtractor implements Serializable {
     return sessions;
   }
 
-  public JavaPairRDD<String, Double> bulidUserItermRDD(
-      JavaRDD<ClickStream> clickstreamRDD) {
-    return clickstreamRDD
-        .mapToPair(new PairFunction<ClickStream, String, Double>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+  public JavaPairRDD<String, Double> bulidUserItermRDD(JavaRDD<ClickStream> clickstreamRDD) {
+    return clickstreamRDD.mapToPair(new PairFunction<ClickStream, String, Double>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Tuple2<String, Double> call(ClickStream click)
-              throws Exception {
-            double rate = 1;
-            boolean download = click.isDownload();
-            if (download) {
-              rate = 2;
-            }
+      @Override
+      public Tuple2<String, Double> call(ClickStream click) throws Exception {
+        double rate = 1;
+        boolean download = click.isDownload();
+        if (download) {
+          rate = 2;
+        }
 
-            String sessionID = click.getSessionID();
-            String user = sessionID.split("@")[0];
+        String sessionID = click.getSessionID();
+        String user = sessionID.split("@")[0];
 
-            return new Tuple2<>(user + "," + click.getViewDataset(), rate);
-          }
-        }).reduceByKey(new Function2<Double, Double, Double>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+        return new Tuple2<>(user + "," + click.getViewDataset(), rate);
+      }
+    }).reduceByKey(new Function2<Double, Double, Double>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Double call(Double v1, Double v2) throws Exception {
-            return v1 >= v2 ? v1 : v2;
+      @Override
+      public Double call(Double v1, Double v2) throws Exception {
+        return v1 >= v2 ? v1 : v2;
 
-          }
-        });
+      }
+    });
   }
 
-  public JavaPairRDD<String, Double> bulidSessionItermRDD(
-      JavaRDD<ClickStream> clickstreamRDD, int filterOpt) {
-    JavaPairRDD<String, String> sessionItemRDD = clickstreamRDD
-        .mapToPair(new PairFunction<ClickStream, String, String>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+  public JavaPairRDD<String, Double> bulidSessionItermRDD(JavaRDD<ClickStream> clickstreamRDD, int filterOpt) {
+    JavaPairRDD<String, String> sessionItemRDD = clickstreamRDD.mapToPair(new PairFunction<ClickStream, String, String>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Tuple2<String, String> call(ClickStream click)
-              throws Exception {
+      @Override
+      public Tuple2<String, String> call(ClickStream click) throws Exception {
 
-            String sessionID = click.getSessionID();
-            return new Tuple2<>(sessionID, click.getViewDataset());
-          }
-        }).distinct();
+        String sessionID = click.getSessionID();
+        return new Tuple2<>(sessionID, click.getViewDataset());
+      }
+    }).distinct();
 
     // remove some sessions
-    JavaPairRDD<String, Double> sessionItemNumRDD = sessionItemRDD.keys()
-        .mapToPair(new PairFunction<String, String, Double>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+    JavaPairRDD<String, Double> sessionItemNumRDD = sessionItemRDD.keys().mapToPair(new PairFunction<String, String, Double>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Tuple2<String, Double> call(String item) throws Exception {
-            return new Tuple2<>(item, 1.0);
-          }
-        }).reduceByKey(new Function2<Double, Double, Double>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+      @Override
+      public Tuple2<String, Double> call(String item) throws Exception {
+        return new Tuple2<>(item, 1.0);
+      }
+    }).reduceByKey(new Function2<Double, Double, Double>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Double call(Double v1, Double v2) throws Exception {
-            return v1 + v2;
-          }
-        }).filter(new Function<Tuple2<String, Double>, Boolean>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+      @Override
+      public Double call(Double v1, Double v2) throws Exception {
+        return v1 + v2;
+      }
+    }).filter(new Function<Tuple2<String, Double>, Boolean>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Boolean call(Tuple2<String, Double> arg0) throws Exception {
-            Boolean b = true;
-            if (arg0._2 < 2) {
-              b = false;
-            }
-            return b;
-          }
-        });
+      @Override
+      public Boolean call(Tuple2<String, Double> arg0) throws Exception {
+        Boolean b = true;
+        if (arg0._2 < 2) {
+          b = false;
+        }
+        return b;
+      }
+    });
 
-    return sessionItemNumRDD.leftOuterJoin(sessionItemRDD).mapToPair(
-        new PairFunction<Tuple2<String, Tuple2<Double, Optional<String>>>, String, Double>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+    return sessionItemNumRDD.leftOuterJoin(sessionItemRDD).mapToPair(new PairFunction<Tuple2<String, Tuple2<Double, Optional<String>>>, String, Double>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Tuple2<String, Double> call(
-              Tuple2<String, Tuple2<Double, Optional<String>>> arg0)
-              throws Exception {
+      @Override
+      public Tuple2<String, Double> call(Tuple2<String, Tuple2<Double, Optional<String>>> arg0) throws Exception {
 
-            Tuple2<Double, Optional<String>> test = arg0._2;
-            Optional<String> optStr = test._2;
-            String item = "";
-            if (optStr.isPresent()) {
-              item = optStr.get();
-            }
-            return new Tuple2<>(arg0._1 + "," + item, 1.0);
-          }
+        Tuple2<Double, Optional<String>> test = arg0._2;
+        Optional<String> optStr = test._2;
+        String item = "";
+        if (optStr.isPresent()) {
+          item = optStr.get();
+        }
+        return new Tuple2<>(arg0._1 + "," + item, 1.0);
+      }
 
-        });
+    });
   }
 
-  public JavaPairRDD<String, List<String>> bulidSessionDatasetRDD(
-      Properties props, ESDriver es, SparkDriver spark) {
+  public JavaPairRDD<String, List<String>> bulidSessionDatasetRDD(Properties props, ESDriver es, SparkDriver spark) {
 
-    ArrayList<String> sessionstaticTypeList = (ArrayList<String>) es
-        .getTypeListWithPrefix(props.getProperty("indexName"),
-            props.getProperty("SessionStats_prefix"));
+    ArrayList<String> sessionstaticTypeList = (ArrayList<String>) es.getTypeListWithPrefix(props.getProperty("indexName"), props.getProperty("SessionStats_prefix"));
     List<String> result = new ArrayList<>();
     for (int n = 0; n < sessionstaticTypeList.size(); n++) {
 
       String staticType = sessionstaticTypeList.get(n);
 
-      SearchResponse scrollResp = es.getClient()
-          .prepareSearch(props.getProperty(MudrodConstants.ES_INDEX_NAME))
-          .setTypes(staticType).setScroll(new TimeValue(60000))
-          .setQuery(QueryBuilders.matchAllQuery()).setSize(100).execute()
-          .actionGet();
+      SearchResponse scrollResp = es.getClient().prepareSearch(props.getProperty(MudrodConstants.ES_INDEX_NAME)).setTypes(staticType).setScroll(new TimeValue(60000))
+          .setQuery(QueryBuilders.matchAllQuery()).setSize(100).execute().actionGet();
       while (true) {
         for (SearchHit hit : scrollResp.getHits().getHits()) {
           Map<String, Object> session = hit.getSource();
@@ -419,9 +380,7 @@ public class SessionExtractor implements Serializable {
           }
         }
 
-        scrollResp = es.getClient()
-            .prepareSearchScroll(scrollResp.getScrollId())
-            .setScroll(new TimeValue(600000)).execute().actionGet();
+        scrollResp = es.getClient().prepareSearchScroll(scrollResp.getScrollId()).setScroll(new TimeValue(600000)).execute().actionGet();
         if (scrollResp.getHits().getHits().length == 0) {
           break;
         }
@@ -430,32 +389,30 @@ public class SessionExtractor implements Serializable {
 
     JavaRDD<String> sessionRDD = spark.sc.parallelize(result);
 
-    return sessionRDD
-        .mapToPair(new PairFunction<String, String, List<String>>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+    return sessionRDD.mapToPair(new PairFunction<String, String, List<String>>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Tuple2<String, List<String>> call(String sessionitem)
-              throws Exception {
-            String[] splits = sessionitem.split(":");
-            String sessionId = splits[0];
-            List<String> itemList = new ArrayList<>();
+      @Override
+      public Tuple2<String, List<String>> call(String sessionitem) throws Exception {
+        String[] splits = sessionitem.split(":");
+        String sessionId = splits[0];
+        List<String> itemList = new ArrayList<>();
 
-            String items = splits[1];
-            String[] itemArr = items.split(",");
-            int size = itemArr.length;
-            for (int i = 0; i < size; i++) {
-              String item = itemArr[i];
-              if (!itemList.contains(item))
-                itemList.add(itemArr[i]);
-            }
+        String items = splits[1];
+        String[] itemArr = items.split(",");
+        int size = itemArr.length;
+        for (int i = 0; i < size; i++) {
+          String item = itemArr[i];
+          if (!itemList.contains(item))
+            itemList.add(itemArr[i]);
+        }
 
-            return new Tuple2<>(sessionId, itemList);
-          }
-        });
+        return new Tuple2<>(sessionId, itemList);
+      }
+    });
   }
 
   /**
@@ -468,8 +425,7 @@ public class SessionExtractor implements Serializable {
    * @return clickstream list in JavaRDD format
    * {@link ClickStream}
    */
-  public JavaRDD<RankingTrainData> extractRankingTrainData(Properties props,
-      ESDriver es, SparkDriver spark) {
+  public JavaRDD<RankingTrainData> extractRankingTrainData(Properties props, ESDriver es, SparkDriver spark) {
 
     List<RankingTrainData> queryList = this.extractRankingTrainData(props, es);
     return spark.sc.parallelize(queryList);
@@ -484,10 +440,8 @@ public class SessionExtractor implements Serializable {
    * @return clickstream list
    * {@link ClickStream}
    */
-  protected List<RankingTrainData> extractRankingTrainData(Properties props,
-      ESDriver es) {
-    List<String> logIndexList = es
-        .getIndexListWithPrefix(props.getProperty(MudrodConstants.LOG_INDEX));
+  protected List<RankingTrainData> extractRankingTrainData(Properties props, ESDriver es) {
+    List<String> logIndexList = es.getIndexListWithPrefix(props.getProperty(MudrodConstants.LOG_INDEX));
 
     System.out.println(logIndexList.toString());
 
@@ -501,8 +455,7 @@ public class SessionExtractor implements Serializable {
         int sessionNum = sessionIdList.size();
         for (int i = 0; i < sessionNum; i++) {
           String[] sArr = sessionIdList.get(i).split(",");
-          List<RankingTrainData> datas = session
-              .getRankingTrainData(sArr[1], sArr[2], sArr[0]);
+          List<RankingTrainData> datas = session.getRankingTrainData(sArr[1], sArr[2], sArr[0]);
           result.addAll(datas);
         }
       } catch (Exception e) {
@@ -513,11 +466,9 @@ public class SessionExtractor implements Serializable {
     return result;
   }
 
-  protected JavaRDD<RankingTrainData> extractRankingTrainDataInParallel(
-      Properties props, SparkDriver spark, ESDriver es) {
+  protected JavaRDD<RankingTrainData> extractRankingTrainDataInParallel(Properties props, SparkDriver spark, ESDriver es) {
 
-    List<String> logIndexList = es
-        .getIndexListWithPrefix(props.getProperty(MudrodConstants.LOG_INDEX));
+    List<String> logIndexList = es.getIndexListWithPrefix(props.getProperty(MudrodConstants.LOG_INDEX));
 
     System.out.print(logIndexList.toString());
 
@@ -530,32 +481,29 @@ public class SessionExtractor implements Serializable {
 
     JavaRDD<String> sessionRDD = spark.sc.parallelize(sessionIdList, 16);
 
-    JavaRDD<RankingTrainData> ClickStreamRDD = sessionRDD.mapPartitions(
-        new FlatMapFunction<Iterator<String>, RankingTrainData>() {
-          /**
-           *
-           */
-          private static final long serialVersionUID = 1L;
+    JavaRDD<RankingTrainData> ClickStreamRDD = sessionRDD.mapPartitions(new FlatMapFunction<Iterator<String>, RankingTrainData>() {
+      /**
+       *
+       */
+      private static final long serialVersionUID = 1L;
 
-          @Override
-          public Iterator<RankingTrainData> call(Iterator<String> arg0)
-              throws Exception {
-            ESDriver tmpES = new ESDriver(props);
-            tmpES.createBulkProcessor();
+      @Override
+      public Iterator<RankingTrainData> call(Iterator<String> arg0) throws Exception {
+        ESDriver tmpES = new ESDriver(props);
+        tmpES.createBulkProcessor();
 
-            Session session = new Session(props, tmpES);
-            List<RankingTrainData> clickstreams = new ArrayList<>();
-            while (arg0.hasNext()) {
-              String s = arg0.next();
-              String[] sArr = s.split(",");
-              List<RankingTrainData> clicks = session
-                  .getRankingTrainData(sArr[1], sArr[2], sArr[0]);
-              clickstreams.addAll(clicks);
-            }
-            tmpES.destroyBulkProcessor();
-            return clickstreams.iterator();
-          }
-        });
+        Session session = new Session(props, tmpES);
+        List<RankingTrainData> clickstreams = new ArrayList<>();
+        while (arg0.hasNext()) {
+          String s = arg0.next();
+          String[] sArr = s.split(",");
+          List<RankingTrainData> clicks = session.getRankingTrainData(sArr[1], sArr[2], sArr[0]);
+          clickstreams.addAll(clicks);
+        }
+        tmpES.destroyBulkProcessor();
+        return clickstreams.iterator();
+      }
+    });
 
     System.out.println("click stream number:" + ClickStreamRDD.count());
 

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/SessionNode.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/SessionNode.java
@@ -65,8 +65,7 @@ public class SessionNode {
    * @param time:    request time of node
    * @param seq:     sequence of this node
    */
-  public SessionNode(String request, String logType, String referer,
-      String time, int seq) {
+  public SessionNode(String request, String logType, String referer, String time, int seq) {
     this.logType = logType;
     this.time = time;
     this.seq = seq;
@@ -85,8 +84,7 @@ public class SessionNode {
       this.referer = "";
       return;
     }
-    this.referer = referer.toLowerCase()
-        .replace("http://podaac.jpl.nasa.gov", "");
+    this.referer = referer.toLowerCase().replace("http://podaac.jpl.nasa.gov", "");
   }
 
   /**

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/SessionTree.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/SessionTree.java
@@ -58,8 +58,7 @@ public class SessionTree extends MudrodAbstract {
    * @param sessionID:   session ID
    * @param cleanupType: session type
    */
-  public SessionTree(Properties props, ESDriver es, SessionNode rootData,
-      String sessionID, String cleanupType) {
+  public SessionTree(Properties props, ESDriver es, SessionNode rootData, String sessionID, String cleanupType) {
     super(props, es, null);
     root = new SessionNode("root", "root", "", "", 0);
     tmpnode = root;
@@ -75,8 +74,7 @@ public class SessionTree extends MudrodAbstract {
    * @param sessionID:   session ID
    * @param cleanupType: session type
    */
-  public SessionTree(Properties props, ESDriver es, String sessionID,
-      String cleanupType) {
+  public SessionTree(Properties props, ESDriver es, String sessionID, String cleanupType) {
     super(props, es, null);
     root = new SessionNode("root", "root", "", "", 0);
     root.setParent(root);
@@ -100,8 +98,7 @@ public class SessionTree extends MudrodAbstract {
       return null;
     }
     // remove unrelated node
-    if (!node.getKey().equals("datasetlist") && !node.getKey().equals("dataset")
-        && !node.getKey().equals("ftp")) {
+    if (!node.getKey().equals("datasetlist") && !node.getKey().equals("dataset") && !node.getKey().equals("ftp")) {
       return null;
     }
     // remove dumplicated click
@@ -341,8 +338,7 @@ public class SessionTree extends MudrodAbstract {
    * @param children
    * @return
    */
-  private boolean insertHelperChildren(SessionNode entry,
-      List<SessionNode> children) {
+  private boolean insertHelperChildren(SessionNode entry, List<SessionNode> children) {
     for (int i = 0; i < children.size(); i++) {
       boolean result = insertHelper(entry, children.get(i));
       if (result) {
@@ -454,9 +450,7 @@ public class SessionTree extends MudrodAbstract {
    * @throws UnsupportedEncodingException if there is an error whilst
    *                                      processing the ranking training data.
    */
-  public List<RankingTrainData> getRankingTrainData(String indexName,
-      String cleanuptype, String sessionID)
-      throws UnsupportedEncodingException {
+  public List<RankingTrainData> getRankingTrainData(String indexName, String cleanuptype, String sessionID) throws UnsupportedEncodingException {
 
     List<RankingTrainData> trainDatas = new ArrayList<>();
 
@@ -502,8 +496,7 @@ public class SessionTree extends MudrodAbstract {
 
                 String[] queries = query.split(",");
                 for (int l = 0; l < queries.length; l++) {
-                  RankingTrainData trainData = new RankingTrainData(queries[l],
-                      datasetA, datasetB);
+                  RankingTrainData trainData = new RankingTrainData(queries[l], datasetA, datasetB);
 
                   trainData.setSessionId(this.sessionID);
                   trainData.setIndex(indexName);

--- a/core/src/main/resources/config.xml
+++ b/core/src/main/resources/config.xml
@@ -74,8 +74,8 @@
     <para name="metadataTopicSimType">MetadataTBSim</para>
 
 
-    <!-- This should be the absolute path to mudrod/core/src/main/resources/javaSVMWithSGDModel on your system -->
-    <para name="svmSgdModel">file://YOUNEEDTOCHANGETHIS</para>
+    <!-- This should be the name of the compressed archive included as a resource with the core JAR -->
+    <para name="svmSgdModel">javaSVMWithSGDModel.tar.gz</para>
 
     <!--
     The ontology service implementation. Possible values include

--- a/core/src/main/resources/elastic_mappings.json
+++ b/core/src/main/resources/elastic_mappings.json
@@ -60,8 +60,8 @@
         "type": "string",
         "index": "not_analyzed"
       },
-      "Dataset-Metadata" : {
-        "type" : "completion"
+      "Dataset-Metadata": {
+        "type": "completion"
       }
     }
   }

--- a/eclipse-codeformat.xml
+++ b/eclipse-codeformat.xml
@@ -216,7 +216,7 @@
         <setting
                 id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment"
                 value="false"/>
-        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="200"/>
         <setting
                 id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if"
                 value="insert"/>

--- a/service/src/main/java/gov/nasa/jpl/mudrod/services/MudrodContextListener.java
+++ b/service/src/main/java/gov/nasa/jpl/mudrod/services/MudrodContextListener.java
@@ -62,8 +62,7 @@ public class MudrodContextListener implements ServletContextListener {
 
     ServletContext ctx = arg0.getServletContext();
     Searcher searcher = new Searcher(props, me.getESDriver(), null);
-    Ranker ranker = new Ranker(props, me.getESDriver(), me.getSparkDriver(),
-        "SparkSVM");
+    Ranker ranker = new Ranker(props, me.getESDriver(), me.getSparkDriver(), "SparkSVM");
     Ontology ontImpl = new OntologyFactory(props).getOntology();
     ctx.setAttribute("MudrodInstance", me);
     ctx.setAttribute("MudrodSearcher", searcher);

--- a/service/src/main/java/gov/nasa/jpl/mudrod/services/autocomplete/AutoCompleteResource.java
+++ b/service/src/main/java/gov/nasa/jpl/mudrod/services/autocomplete/AutoCompleteResource.java
@@ -18,7 +18,7 @@ import gov.nasa.jpl.mudrod.main.MudrodConstants;
 import gov.nasa.jpl.mudrod.main.MudrodEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import javax.ws.rs.QueryParam;
+
 import javax.servlet.ServletContext;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
@@ -33,8 +33,7 @@ import java.util.List;
 @Path("/autocomplete")
 public class AutoCompleteResource {
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(AutoCompleteResource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AutoCompleteResource.class);
   private MudrodEngine mEngine;
 
   public AutoCompleteResource(@Context ServletContext sc) {
@@ -45,9 +44,7 @@ public class AutoCompleteResource {
   @Path("/status")
   @Produces("text/html")
   public Response status() {
-    return Response
-        .ok("<h1>This is MUDROD AutoCompleteResource: running correctly...</h1>")
-        .build();
+    return Response.ok("<h1>This is MUDROD AutoCompleteResource: running correctly...</h1>").build();
   }
 
   @GET
@@ -56,8 +53,7 @@ public class AutoCompleteResource {
   @Consumes("text/plain")
   public Response autoComplete(@QueryParam("term") String term) {
     List<AutoCompleteData> result = new ArrayList<>();
-    List<String> suggestList = mEngine.getESDriver().autoComplete(
-        mEngine.getConfig().getProperty(MudrodConstants.ES_INDEX_NAME), term);
+    List<String> suggestList = mEngine.getESDriver().autoComplete(mEngine.getConfig().getProperty(MudrodConstants.ES_INDEX_NAME), term);
     for (final String item : suggestList) {
       result.add(new AutoCompleteData(item, item));
     }

--- a/service/src/main/java/gov/nasa/jpl/mudrod/services/ontology/OntologyResource.java
+++ b/service/src/main/java/gov/nasa/jpl/mudrod/services/ontology/OntologyResource.java
@@ -33,8 +33,7 @@ import java.util.List;
 @Path("/ontology")
 public class OntologyResource {
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(OntologyResource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(OntologyResource.class);
   private Ontology ontImpl;
 
   public OntologyResource(@Context ServletContext sc) {
@@ -45,9 +44,7 @@ public class OntologyResource {
   @Path("/status")
   @Produces("text/html")
   public Response status() {
-    return Response
-        .ok("<h1>This is MUDROD Ontology-driven User Query Augmentation Resource: running correctly...</h1>")
-        .build();
+    return Response.ok("<h1>This is MUDROD Ontology-driven User Query Augmentation Resource: running correctly...</h1>").build();
   }
 
   @GET

--- a/service/src/main/java/gov/nasa/jpl/mudrod/services/recommendation/HybridRecomDatasetsResource.java
+++ b/service/src/main/java/gov/nasa/jpl/mudrod/services/recommendation/HybridRecomDatasetsResource.java
@@ -39,24 +39,19 @@ public class HybridRecomDatasetsResource {
   @Path("/status")
   @Produces("text/html")
   public Response status() {
-    return Response
-        .ok("<h1>This is MUDROD Hybrid Recommendation Datasets Resource: running correctly...</h1>")
-        .build();
+    return Response.ok("<h1>This is MUDROD Hybrid Recommendation Datasets Resource: running correctly...</h1>").build();
   }
 
   @GET
   @Path("/search")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes("text/plain")
-  public Response hybridRecommendation(
-      @QueryParam("shortname") String shortName) {
+  public Response hybridRecommendation(@QueryParam("shortname") String shortName) {
     JsonObject json = new JsonObject();
     if (shortName != null) {
-      HybridRecommendation recom = new HybridRecommendation(mEngine.getConfig(),
-          mEngine.getESDriver(), null);
+      HybridRecommendation recom = new HybridRecommendation(mEngine.getConfig(), mEngine.getESDriver(), null);
       json = new JsonObject();
-      json.add("HybridRecommendationData",
-          recom.getRecomDataInJson(shortName, 10));
+      json.add("HybridRecommendationData", recom.getRecomDataInJson(shortName, 10));
     }
     return Response.ok(json.toString(), MediaType.APPLICATION_JSON).build();
   }

--- a/service/src/main/java/gov/nasa/jpl/mudrod/services/recommendation/RecomDatasetsResource.java
+++ b/service/src/main/java/gov/nasa/jpl/mudrod/services/recommendation/RecomDatasetsResource.java
@@ -41,21 +41,17 @@ public class RecomDatasetsResource {
   @Path("/status")
   @Produces("text/html")
   public Response status() {
-    return Response
-        .ok("<h1>This is MUDROD Recommendation Datasets Resource: running correctly...</h1>")
-        .build();
+    return Response.ok("<h1>This is MUDROD Recommendation Datasets Resource: running correctly...</h1>").build();
   }
 
   @PUT
   @Path("{shortname}")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes("text/plain")
-  public Response hybridRecommendation(
-      @PathParam("shortname") String shortName) {
+  public Response hybridRecommendation(@PathParam("shortname") String shortName) {
     JsonObject json = new JsonObject();
     if (shortName != null) {
-      RecomData recom = new RecomData(mEngine.getConfig(),
-          mEngine.getESDriver(), null);
+      RecomData recom = new RecomData(mEngine.getConfig(), mEngine.getESDriver(), null);
       json = new JsonObject();
       json.add("RecommendationData", recom.getRecomDataInJson(shortName, 10));
     }

--- a/service/src/main/java/gov/nasa/jpl/mudrod/services/search/SearchDatasetDetailResource.java
+++ b/service/src/main/java/gov/nasa/jpl/mudrod/services/search/SearchDatasetDetailResource.java
@@ -33,8 +33,7 @@ import java.util.concurrent.ExecutionException;
 @Path("/datasetdetail")
 public class SearchDatasetDetailResource {
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(SearchDatasetDetailResource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SearchDatasetDetailResource.class);
   private MudrodEngine mEngine;
 
   public SearchDatasetDetailResource(@Context ServletContext sc) {
@@ -50,26 +49,20 @@ public class SearchDatasetDetailResource {
   @Path("/status")
   @Produces("text/html")
   public Response status() {
-    return Response
-        .ok("<h1>This is MUDROD Dataset Detail Search Resource: running correctly...</h1>")
-        .build();
+    return Response.ok("<h1>This is MUDROD Dataset Detail Search Resource: running correctly...</h1>").build();
   }
 
   @GET
   @Path("/search")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes("text/plain")
-  public Response searchDatasetDetail(
-      @QueryParam("shortname") String shortName) {
+  public Response searchDatasetDetail(@QueryParam("shortname") String shortName) {
 
     Properties config = mEngine.getConfig();
     String dataDetailJson = null;
     try {
       String query = "Dataset-ShortName:\"" + shortName + "\"";
-      dataDetailJson = mEngine.getESDriver()
-          .searchByQuery(config.getProperty(MudrodConstants.ES_INDEX_NAME),
-              config.getProperty(MudrodConstants.RAW_METADATA_TYPE), query,
-              true);
+      dataDetailJson = mEngine.getESDriver().searchByQuery(config.getProperty(MudrodConstants.ES_INDEX_NAME), config.getProperty(MudrodConstants.RAW_METADATA_TYPE), query, true);
     } catch (InterruptedException | ExecutionException | IOException e) {
       LOG.error("Error whilst searching for a Dataset-ShortName", e);
     }

--- a/service/src/main/java/gov/nasa/jpl/mudrod/services/search/SearchMetadataResource.java
+++ b/service/src/main/java/gov/nasa/jpl/mudrod/services/search/SearchMetadataResource.java
@@ -36,8 +36,7 @@ import java.util.Properties;
 @Path("/metadata")
 public class SearchMetadataResource {
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(SearchMetadataResource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SearchMetadataResource.class);
 
   private MudrodEngine mEngine;
   private Searcher searcher;
@@ -53,22 +52,17 @@ public class SearchMetadataResource {
   @Path("/status")
   @Produces("text/html")
   public Response status() {
-    return Response
-        .ok("<h1>This is MUDROD Metadata Search Resource: running correctly...</h1>")
-        .build();
+    return Response.ok("<h1>This is MUDROD Metadata Search Resource: running correctly...</h1>").build();
   }
 
   @GET
   @Path("/search")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes("text/plain")
-  public Response searchMetadata(@QueryParam("query") String query,
-      @QueryParam("operator") String operator) {
+  public Response searchMetadata(@QueryParam("query") String query, @QueryParam("operator") String operator) {
     Properties config = mEngine.getConfig();
     String fileList = searcher
-        .ssearch(config.getProperty(MudrodConstants.ES_INDEX_NAME),
-            config.getProperty(MudrodConstants.RAW_METADATA_TYPE), query,
-            operator, //please replace it with and, or, phrase
+        .ssearch(config.getProperty(MudrodConstants.ES_INDEX_NAME), config.getProperty(MudrodConstants.RAW_METADATA_TYPE), query, operator, //please replace it with and, or, phrase
             ranker);
     Gson gson = new GsonBuilder().create();
     String json = gson.toJson(gson.fromJson(fileList, JsonObject.class));

--- a/service/src/main/java/gov/nasa/jpl/mudrod/services/search/SearchVocabResource.java
+++ b/service/src/main/java/gov/nasa/jpl/mudrod/services/search/SearchVocabResource.java
@@ -32,8 +32,7 @@ import javax.ws.rs.core.Response;
 @Path("/vocabulary")
 public class SearchVocabResource {
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(SearchMetadataResource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SearchMetadataResource.class);
 
   private MudrodEngine mEngine;
 
@@ -45,9 +44,7 @@ public class SearchVocabResource {
   @Path("/status")
   @Produces("text/html")
   public Response status() {
-    return Response
-        .ok("<h1>This is MUDROD Vocabulary Search Resource: running correctly...</h1>")
-        .build();
+    return Response.ok("<h1>This is MUDROD Vocabulary Search Resource: running correctly...</h1>").build();
   }
 
   @GET
@@ -57,14 +54,12 @@ public class SearchVocabResource {
   public Response searchVocabulary(@QueryParam("query") String concept) {
     JsonObject json = new JsonObject();
     if (concept != null) {
-      LinkageIntegration li = new LinkageIntegration(mEngine.getConfig(),
-          mEngine.getESDriver(), null);
+      LinkageIntegration li = new LinkageIntegration(mEngine.getConfig(), mEngine.getESDriver(), null);
       json = new JsonObject();
       json.add("graph", li.getIngeratedListInJson(concept));
     }
     LOG.info("Response received: {}", json);
-    return Response.ok(new Gson().toJson(json), MediaType.APPLICATION_JSON)
-        .build();
+    return Response.ok(new Gson().toJson(json), MediaType.APPLICATION_JSON).build();
   }
 
 }

--- a/service/src/main/java/gov/nasa/jpl/mudrod/services/search/SessionDetailResource.java
+++ b/service/src/main/java/gov/nasa/jpl/mudrod/services/search/SessionDetailResource.java
@@ -33,8 +33,7 @@ import javax.ws.rs.core.Response;
 @Path("/sessiondetail")
 public class SessionDetailResource {
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(SessionDetailResource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SessionDetailResource.class);
   private MudrodEngine mEngine;
 
   /**
@@ -50,28 +49,21 @@ public class SessionDetailResource {
   @Path("/status")
   @Produces("text/html")
   public Response status() {
-    return Response
-        .ok("<h1>This is MUDROD Session Detail Search Resource: running correctly...</h1>")
-        .build();
+    return Response.ok("<h1>This is MUDROD Session Detail Search Resource: running correctly...</h1>").build();
   }
 
   @POST
   @Path("{CleanupType}-{SessionID}")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes("text/plain")
-  protected Response searchSessionDetail(
-      @PathParam("CleanupType") String cleanupType,
-      @PathParam("SessionID") String sessionID) {
+  protected Response searchSessionDetail(@PathParam("CleanupType") String cleanupType, @PathParam("SessionID") String sessionID) {
 
     JsonObject json = new JsonObject();
     if (sessionID != null) {
       Session session = new Session(mEngine.getConfig(), mEngine.getESDriver());
-      json = session.getSessionDetail(mEngine.getConfig()
-              .getProperty(MudrodConstants.ES_INDEX_NAME, "mudrod"), cleanupType,
-          sessionID);
+      json = session.getSessionDetail(mEngine.getConfig().getProperty(MudrodConstants.ES_INDEX_NAME, "mudrod"), cleanupType, sessionID);
     }
     LOG.info("Response received: {}", json);
-    return Response.ok(new Gson().toJson(json), MediaType.APPLICATION_JSON)
-        .build();
+    return Response.ok(new Gson().toJson(json), MediaType.APPLICATION_JSON).build();
   }
 }

--- a/web/META-INF/resources/css/autocomplete.css
+++ b/web/META-INF/resources/css/autocomplete.css
@@ -1,56 +1,55 @@
 .tt-menu,
 .gist {
-  text-align: left;
+    text-align: left;
 }
-
 
 .typeahead,
 .tt-query,
 .tt-hint {
-  width: 396px;
-  height: 43px;
-  padding: 8px 12px;
-  font-size: 16px;
-  line-height: 30px;
-  border: 2px solid #ccc;
-  -webkit-border-radius: 8px;
-     -moz-border-radius: 8px;
-          border-radius: 8px;
-  outline: none;
+    width: 396px;
+    height: 43px;
+    padding: 8px 12px;
+    font-size: 16px;
+    line-height: 30px;
+    border: 2px solid #ccc;
+    -webkit-border-radius: 8px;
+    -moz-border-radius: 8px;
+    border-radius: 8px;
+    outline: none;
 }
 
 .typeahead {
-  background-color: #fff;
+    background-color: #fff;
 }
 
 .typeahead:focus {
-  border: 2px solid #0097cf;
+    border: 2px solid #0097cf;
 }
 
 .tt-query {
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-     -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-          box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
 
 .tt-hint {
-  color: #999
+    color: #999
 }
 
 .tt-menu {
-  width: 540px;
-  margin: 12px 0;
-  padding: 8px 0;
-  background-color: #fff;
-  color: #428bca;
-  border: 1px solid #ccc;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  -webkit-border-radius: 0px 0px 8px 8px;
-     -moz-border-radius: 0px 0px 8px 8px;
-          border-radius: 0px 0px 8px 8px;
-  -webkit-box-shadow: 0 5px 10px rgba(0,0,0,.2);
-     -moz-box-shadow: 0 5px 10px rgba(0,0,0,.2);
-          box-shadow: 0 5px 10px rgba(0,0,0,.2);
+    width: 540px;
+    margin: 12px 0;
+    padding: 8px 0;
+    background-color: #fff;
+    color: #428bca;
+    border: 1px solid #ccc;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    -webkit-border-radius: 0px 0px 8px 8px;
+    -moz-border-radius: 0px 0px 8px 8px;
+    border-radius: 0px 0px 8px 8px;
+    -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, .2);
+    -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, .2);
+    box-shadow: 0 5px 10px rgba(0, 0, 0, .2);
 }
 
 .tt-suggestion {
@@ -60,27 +59,28 @@
 }
 
 .tt-suggestion:hover {
-  cursor: pointer;
-  color: #fff;
-  background-color: #0097cf;
+    cursor: pointer;
+    color: #fff;
+    background-color: #0097cf;
 }
 
 .tt-suggestion.tt-cursor {
-  color: #fff;
-  background-color: #0097cf;
+    color: #fff;
+    background-color: #0097cf;
 
 }
 
 .tt-suggestion p {
-  margin: 0;
+    margin: 0;
 }
 
 .gist {
-  font-size: 14px;
+    font-size: 14px;
 }
 
 .twitter-typeahead .tt-dropdown-menu {
-  max-height: 150px;
-  overflow-y: auto;
+    max-height: 150px;
+    overflow-y: auto;
 }
+
 \ No newline at end of file

--- a/web/META-INF/resources/js/index.js
+++ b/web/META-INF/resources/js/index.js
@@ -12,20 +12,20 @@
  * limitations under the License.
  */
 $(document).ready(function () {
-	var bestPictures = new Bloodhound({
-  	  datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
-  	  queryTokenizer: Bloodhound.tokenizers.whitespace,
-  	  remote: {
-  	    url: 'services/autocomplete/query?term=%QUERY',
-  	    wildcard: '%QUERY'
-  	  }
-  	});
+    var bestPictures = new Bloodhound({
+        datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
+        queryTokenizer: Bloodhound.tokenizers.whitespace,
+        remote: {
+            url: 'services/autocomplete/query?term=%QUERY',
+            wildcard: '%QUERY'
+        }
+    });
 
-  	$('#query').typeahead(null, {
-  	  display: 'value',
-  	  source: bestPictures
-  	});
-	  	
+    $('#query').typeahead(null, {
+        display: 'value',
+        source: bestPictures
+    });
+
     $("#query").keyup(function (event) {
         if (event.keyCode == 13) {
             $("#searchButton").click();

--- a/web/META-INF/resources/js/search.js
+++ b/web/META-INF/resources/js/search.js
@@ -42,20 +42,20 @@ $(document).ready(function () {
     $("#ontologyUL").on("click", "li a", function () {
         redirect("search", "query", $(this).data("word"), "searchOption", $("input[name='searchOption']:checked").val());
     });
-    
-    var bestPictures = new Bloodhound({
-  	  datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
-  	  queryTokenizer: Bloodhound.tokenizers.whitespace,
-  	  remote: {
-  	    url: 'services/autocomplete/query?term=%QUERY',
-  	    wildcard: '%QUERY'
-  	  }
-  	});
 
-  	$('#query').typeahead(null, {
-  	  display: 'value',
-  	  source: bestPictures
-  	});
+    var bestPictures = new Bloodhound({
+        datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
+        queryTokenizer: Bloodhound.tokenizers.whitespace,
+        remote: {
+            url: 'services/autocomplete/query?term=%QUERY',
+            wildcard: '%QUERY'
+        }
+    });
+
+    $('#query').typeahead(null, {
+        display: 'value',
+        source: bestPictures
+    });
 });
 
 function search(query) {
@@ -171,11 +171,11 @@ function createResultTable() {
         }, {
             'title': 'Long Name',
             'field': 'Long Name',
-        } ,{
-        	'title': 'Topic',
-	        'field': 'Topic',
-	        'formatter': TopicFormatter,
-        },{
+        }, {
+            'title': 'Topic',
+            'field': 'Topic',
+            'formatter': TopicFormatter,
+        }, {
             'title': 'Platform/Sensors',
             'field': 'Sensor',
         }, {


### PR DESCRIPTION
This pull request fixes https://github.com/mudrod/mudrod/issues/119. It also includes some code format updates (increased line width from 80 to 200).

The way this works now is:

1. During the maven `generate-resources` phase, the assembly plugin execution with id `zipSVMWithSGDModel` is executed.
2. The `zipSVMWithSGDModel` execution uses `mudrod/core/src/main/assembly/zipSVMWithSGDModel.xml` to create a tar.gz archive of `mudrod/core/src/main/resources/javaSVMWithSGDModel`. The created archive called `javaSVMWithSGDModel.tar.gz` is placed into the `target` directory
3. The maven resources plugin excludes the `mudrod/core/src/main/resources/javaSVMWithSGDModel` directory and includes the `javaSVMWithSGDModel.tar.gz` archive so that the archive is placed in the root of the generated JAR file
4. When the application is started `gov.nasa.jpl.mudrod.main.MudrodEngine#loadConfig` calls the new method `gov.nasa.jpl.mudrod.main.MudrodEngine#decompressSVMWithSGDModel`. This method loads the archive from the classpath, decompresses it into a temporary directory, and returns the absolute file path to the new temporary directory
5. The absolute file path to the temporary directory is then passed on to the loader as before.