### PR TITLE
Intermediate fix for Mudrod 128

### DIFF
--- a/service/src/main/java/gov/nasa/jpl/mudrod/services/DefaultExceptionMapper.java
+++ b/service/src/main/java/gov/nasa/jpl/mudrod/services/DefaultExceptionMapper.java
@@ -26,13 +26,13 @@ import java.util.UUID;
  * Created by greguska on 4/11/17.
  */
 @Provider
-public class DefaultExceptionMapper implements ExceptionMapper<Exception> {
+public class DefaultExceptionMapper implements ExceptionMapper<Throwable> {
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultExceptionMapper.class);
 
   @Override
   @Produces("text/html")
-  public Response toResponse(Exception e) {
+  public Response toResponse(Throwable e) {
 
     UUID errorId = UUID.randomUUID();
     LOG.error("Internal server error " + errorId.toString(), e);

--- a/service/src/main/java/gov/nasa/jpl/mudrod/services/DefaultExceptionMapper.java
+++ b/service/src/main/java/gov/nasa/jpl/mudrod/services/DefaultExceptionMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gov.nasa.jpl.mudrod.services;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import java.util.UUID;
+
+/**
+ * Created by greguska on 4/11/17.
+ */
+@Provider
+public class DefaultExceptionMapper implements ExceptionMapper<Exception> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultExceptionMapper.class);
+
+  @Override
+  @Produces("text/html")
+  public Response toResponse(Exception e) {
+
+    UUID errorId = UUID.randomUUID();
+    LOG.error("Internal server error " + errorId.toString(), e);
+
+    return Response.serverError()
+        .entity("<p>An error occurred while processing your request. Please contact the system administrator and provide the following error log ID " + errorId.toString() + "</p>").build();
+  }
+}

--- a/service/src/main/webapp/WEB-INF/web.xml
+++ b/service/src/main/webapp/WEB-INF/web.xml
@@ -35,6 +35,10 @@
                 gov.nasa.jpl.mudrod.services.ontology.OntologyResource,
             </param-value>
         </init-param>
+        <init-param>
+            <param-name>jaxrs.providers</param-name>
+            <param-value>gov.nasa.jpl.mudrod.services.DefaultExceptionMapper</param-value>
+        </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>
 


### PR DESCRIPTION
The issue https://github.com/mudrod/mudrod/issues/128 brought to light that when the server throws an exception, sensitive information is returned to the client. This pull request adds a default exception mapper to the server so that information is no longer leaked to the client but is still written to the log.