### PR TITLE
Mudrod 163 - Full Ingest - Missing metadata_session_coocurrence_matrix.csv

### DIFF
--- a/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/pre/SessionCooccurence.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/pre/SessionCooccurence.java
@@ -39,9 +39,12 @@ public class SessionCooccurence extends DiscoveryStepAbstract {
   /**
    * Creates a new instance of SessionCooccurence.
    *
-   * @param props the Mudrod configuration
-   * @param es    the Elasticsearch drive
-   * @param spark the spark driver
+   * @param props
+   *          the Mudrod configuration
+   * @param es
+   *          the Elasticsearch drive
+   * @param spark
+   *          the spark driver
    */
   public SessionCooccurence(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
@@ -63,7 +66,7 @@ public class SessionCooccurence extends DiscoveryStepAbstract {
     LabeledRowMatrix datasetSessionMatrix = MatrixUtil.createWordDocMatrix(sessionFiltedDatasetsRDD, spark.sc);
 
     // export
-    MatrixUtil.exportToCSV(datasetSessionMatrix.rowMatrix, datasetSessionMatrix.rowkeys, datasetSessionMatrix.colkeys, props.getProperty("session_dataset_Matrix"));
+    MatrixUtil.exportToCSV(datasetSessionMatrix.rowMatrix, datasetSessionMatrix.rowkeys, datasetSessionMatrix.colkeys, props.getProperty("session_metadata_Matrix"));
 
     endTime = System.currentTimeMillis();
 
@@ -80,8 +83,10 @@ public class SessionCooccurence extends DiscoveryStepAbstract {
   /**
    * filter out-of-data metadata
    *
-   * @param es              the Elasticsearch drive
-   * @param userDatasetsRDD dataset extracted from session
+   * @param es
+   *          the Elasticsearch drive
+   * @param userDatasetsRDD
+   *          dataset extracted from session
    * @return filtered session datasets
    */
   public JavaPairRDD<String, List<String>> removeRetiredDataset(ESDriver es, JavaPairRDD<String, List<String>> userDatasetsRDD) {
@@ -111,7 +116,8 @@ public class SessionCooccurence extends DiscoveryStepAbstract {
    * getMetadataNameMap: Get on service metadata names, key is lowcase of short
    * name and value is the original short name
    *
-   * @param es the elasticsearch client
+   * @param es
+   *          the elasticsearch client
    * @return a map from lower case metadata name to original metadata name
    */
   private Map<String, String> getOnServiceMetadata(ESDriver es) {

--- a/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/process/sessionBasedCF.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/recommendation/process/sessionBasedCF.java
@@ -17,6 +17,7 @@ import gov.nasa.jpl.mudrod.utils.SimilarityUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.List;
 import java.util.Properties;
 
@@ -30,9 +31,12 @@ public class sessionBasedCF extends DiscoveryStepAbstract {
   /**
    * Creates a new instance of sessionBasedCF.
    *
-   * @param props the Mudrod configuration
-   * @param es    the Elasticsearch drive
-   * @param spark the spark drive
+   * @param props
+   *          the Mudrod configuration
+   * @param es
+   *          the Elasticsearch drive
+   * @param spark
+   *          the spark drive
    */
   public sessionBasedCF(Properties props, ESDriver es, SparkDriver spark) {
     super(props, es, spark);
@@ -45,9 +49,12 @@ public class sessionBasedCF extends DiscoveryStepAbstract {
 
     try {
       String session_metadatFile = props.getProperty("session_metadata_Matrix");
-      SemanticAnalyzer analyzer = new SemanticAnalyzer(props, es, spark);
-      List<LinkageTriple> triples = analyzer.calTermSimfromMatrix(session_metadatFile, SimilarityUtil.SIM_PEARSON, 1);
-      analyzer.saveToES(triples, props.getProperty("indexName"), props.getProperty("metadataSessionBasedSimType"), true, false);
+      File f = new File(session_metadatFile);
+      if (f.exists()) {
+        SemanticAnalyzer analyzer = new SemanticAnalyzer(props, es, spark);
+        List<LinkageTriple> triples = analyzer.calTermSimfromMatrix(session_metadatFile, SimilarityUtil.SIM_PEARSON, 1);
+        analyzer.saveToES(triples, props.getProperty("indexName"), props.getProperty("metadataSessionBasedSimType"), true, false);
+      }
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/SessionExtractor.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/weblog/structure/SessionExtractor.java
@@ -45,18 +45,20 @@ public class SessionExtractor implements Serializable {
   private static final long serialVersionUID = 1L;
 
   public SessionExtractor() {
-    //default constructor
+    // default constructor
   }
 
   /**
    * extractClickStreamFromES:Extract click streams from logs stored in
    * Elasticsearch
    *
-   * @param props the Mudrod configuration
-   * @param es    the Elasticsearch drive
-   * @param spark the spark driver
-   * @return clickstream list in JavaRDD format
-   * {@link ClickStream}
+   * @param props
+   *          the Mudrod configuration
+   * @param es
+   *          the Elasticsearch drive
+   * @param spark
+   *          the spark driver
+   * @return clickstream list in JavaRDD format {@link ClickStream}
    */
   public JavaRDD<ClickStream> extractClickStreamFromES(Properties props, ESDriver es, SparkDriver spark) {
 
@@ -74,10 +76,11 @@ public class SessionExtractor implements Serializable {
   /**
    * getClickStreamList:Extract click streams from logs stored in Elasticsearch.
    *
-   * @param props the Mudrod configuration
-   * @param es    the Elasticsearch driver
-   * @return clickstream list
-   * {@link ClickStream}
+   * @param props
+   *          the Mudrod configuration
+   * @param es
+   *          the Elasticsearch driver
+   * @return clickstream list {@link ClickStream}
    */
   protected List<ClickStream> getClickStreamList(Properties props, ESDriver es) {
     List<String> logIndexList = es.getIndexListWithPrefix(props.getProperty(MudrodConstants.LOG_INDEX));
@@ -153,10 +156,11 @@ public class SessionExtractor implements Serializable {
   /**
    * loadClickStremFromTxt:Load click stream form txt file
    *
-   * @param clickthroughFile txt file
-   * @param sc               the spark context
-   * @return clickstream list in JavaRDD format
-   * {@link ClickStream}
+   * @param clickthroughFile
+   *          txt file
+   * @param sc
+   *          the spark context
+   * @return clickstream list in JavaRDD format {@link ClickStream}
    */
   public JavaRDD<ClickStream> loadClickStremFromTxt(String clickthroughFile, JavaSparkContext sc) {
     return sc.textFile(clickthroughFile).flatMap(new FlatMapFunction<String, ClickStream>() {
@@ -177,8 +181,10 @@ public class SessionExtractor implements Serializable {
   /**
    * bulidDataQueryRDD: convert click stream list to data set queries pairs.
    *
-   * @param clickstreamRDD: click stream data
-   * @param downloadWeight: weight of download behavior
+   * @param clickstreamRDD:
+   *          click stream data
+   * @param downloadWeight:
+   *          weight of download behavior
    * @return JavaPairRDD, key is short name of data set, and values are queries
    */
   public JavaPairRDD<String, List<String>> bulidDataQueryRDD(JavaRDD<ClickStream> clickstreamRDD, int downloadWeight) {
@@ -224,9 +230,12 @@ public class SessionExtractor implements Serializable {
   /**
    * getSessions: Get sessions from logs
    *
-   * @param props    the Mudrod configuration
-   * @param es       the Elasticsearch driver
-   * @param logIndex a log index name
+   * @param props
+   *          the Mudrod configuration
+   * @param es
+   *          the Elasticsearch driver
+   * @param logIndex
+   *          a log index name
    * @return list of session names
    */
   protected List<String> getSessions(Properties props, ESDriver es, String logIndex) {
@@ -362,14 +371,12 @@ public class SessionExtractor implements Serializable {
 
   public JavaPairRDD<String, List<String>> bulidSessionDatasetRDD(Properties props, ESDriver es, SparkDriver spark) {
 
-    ArrayList<String> sessionstaticTypeList = (ArrayList<String>) es.getTypeListWithPrefix(props.getProperty("indexName"), props.getProperty("SessionStats_prefix"));
     List<String> result = new ArrayList<>();
-    for (int n = 0; n < sessionstaticTypeList.size(); n++) {
-
-      String staticType = sessionstaticTypeList.get(n);
-
-      SearchResponse scrollResp = es.getClient().prepareSearch(props.getProperty(MudrodConstants.ES_INDEX_NAME)).setTypes(staticType).setScroll(new TimeValue(60000))
-          .setQuery(QueryBuilders.matchAllQuery()).setSize(100).execute().actionGet();
+    List<String> logIndexList = es.getIndexListWithPrefix(props.getProperty(MudrodConstants.LOG_INDEX));
+    for (int n = 0; n < logIndexList.size(); n++) {
+      String logIndex = logIndexList.get(n);
+      SearchResponse scrollResp = es.getClient().prepareSearch(logIndex).setTypes(props.getProperty("SessionStats_prefix")).setScroll(new TimeValue(60000)).setQuery(QueryBuilders.matchAllQuery())
+          .setSize(100).execute().actionGet();
       while (true) {
         for (SearchHit hit : scrollResp.getHits().getHits()) {
           Map<String, Object> session = hit.getSource();
@@ -391,9 +398,6 @@ public class SessionExtractor implements Serializable {
     JavaRDD<String> sessionRDD = spark.sc.parallelize(result);
 
     return sessionRDD.mapToPair(new PairFunction<String, String, List<String>>() {
-      /**
-       *
-       */
       private static final long serialVersionUID = 1L;
 
       @Override
@@ -420,11 +424,13 @@ public class SessionExtractor implements Serializable {
    * extractClickStreamFromES:Extract click streams from logs stored in
    * Elasticsearch
    *
-   * @param props the Mudrod configuration
-   * @param es    the Elasticsearch drive
-   * @param spark the spark driver
-   * @return clickstream list in JavaRDD format
-   * {@link ClickStream}
+   * @param props
+   *          the Mudrod configuration
+   * @param es
+   *          the Elasticsearch drive
+   * @param spark
+   *          the spark driver
+   * @return clickstream list in JavaRDD format {@link ClickStream}
    */
   public JavaRDD<RankingTrainData> extractRankingTrainData(Properties props, ESDriver es, SparkDriver spark) {
 
@@ -436,10 +442,11 @@ public class SessionExtractor implements Serializable {
   /**
    * getClickStreamList:Extract click streams from logs stored in Elasticsearch.
    *
-   * @param props the Mudrod configuration
-   * @param es    the Elasticsearch driver
-   * @return clickstream list
-   * {@link ClickStream}
+   * @param props
+   *          the Mudrod configuration
+   * @param es
+   *          the Elasticsearch driver
+   * @return clickstream list {@link ClickStream}
    */
   protected List<RankingTrainData> extractRankingTrainData(Properties props, ESDriver es) {
     List<String> logIndexList = es.getIndexListWithPrefix(props.getProperty(MudrodConstants.LOG_INDEX));


### PR DESCRIPTION
Metadata_session_coocurrence_matrix.csv file was missing during full ingestion since monthly logs has been stored into separated indexes and no sessions can be extracted from the "mudrod" index.

Problems described in https://github.com/mudrod/mudrod/issues/163 was soloves in this pr.