### PR TITLE
Remain query and search operator in the search bar when a query is executed

### DIFF
--- a/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/Searcher.java
+++ b/core/src/main/java/gov/nasa/jpl/mudrod/ssearch/Searcher.java
@@ -124,7 +124,10 @@ public class Searcher extends MudrodAbstract implements Serializable {
       String longName = (String) result.get("Dataset-LongName");
 
       ArrayList<String> topicList = (ArrayList<String>) result.get("DatasetParameter-Variable");
-      String topic = String.join(", ", topicList);
+      String topic = "";
+      if(null != topicList){
+        topic = String.join(", ", topicList);
+      }
       String content = (String) result.get("Dataset-Description");
 
       if (!"".equals(content)) {

--- a/web/META-INF/resources/js/app.js
+++ b/web/META-INF/resources/js/app.js
@@ -32,11 +32,11 @@ blogApp.config(['$routeProvider', '$locationProvider',
                 }).when('/metadataView/', {
                     templateUrl: 'partials/metadataResults.html',
                     controller: 'metadataViewCtrl'
-                }).when('/metadataView/:name', {
+                }).when('/metadataView/:query/:opt/', {
                     templateUrl: 'partials/metadataResults.html'
                     //controller: 'metadataViewCtrl',
                     //controllerAs: 'vm'
-                }).when('/datasetView/:shortname', {
+                }).when('/datasetView/:shortname/:query/:opt/', {
                     templateUrl: 'partials/datasetResults.html',
                     controller: 'datasetViewCtrl'
                 });

--- a/web/META-INF/resources/js/controllers.js
+++ b/web/META-INF/resources/js/controllers.js
@@ -20,7 +20,7 @@ var mudrodControllers = angular.module('mudrodControllers', []);
 mudrodControllers.controller('searchCtrl', ['$scope', '$rootScope', '$location', 'Autocomplete', 'SearchOptions', 
     function ($scope, $rootScope, $location, Autocomplete, SearchOptions) {
         $scope.options = {
-            preference: 'And'
+            opt: 'And'
         };
         //$scope.relatedTerms = [];
         //$rootScope.searchOptions = {};
@@ -44,20 +44,20 @@ mudrodControllers.controller('searchCtrl', ['$scope', '$rootScope', '$location',
         }  
 
         $scope.fillTextbox = function(string){  
-            $scope.options.term = string;  
+            $scope.options.query = string;  
             $scope.hidethis = true;  
             $scope.hideoption = false;
         }  
 
         $scope.search = function(options) {
             $rootScope.searchOptions = angular.copy(options);
-            $location.path("/metadataView/" + options.term + '/' + options.preference);
+            $location.path("/metadataView/" + options.query + '/' + options.opt);
         };
 
         $scope.$watch(function () { return SearchOptions.getSearchOptions(); }, function (newValue, oldValue) {
             if (newValue != null) {
-                $scope.options.term= newValue.query;
-                $scope.options.preference= newValue.opt;
+                $scope.options.query= newValue.query;
+                $scope.options.opt= newValue.opt;
             }
         }, true);
     }]);
@@ -65,8 +65,8 @@ mudrodControllers.controller('searchCtrl', ['$scope', '$rootScope', '$location',
 mudrodControllers.controller('vocabularyCtrl', ['$scope', '$rootScope', 'VocabList',
     function vocabularyCtrl($scope, $rootScope, VocabList) {
 
-        var word = $rootScope.searchOptions.term;
-        var opt = $rootScope.searchOptions.preference;
+        var word = $rootScope.searchOptions.query;
+        var opt = $rootScope.searchOptions.opt;
         VocabList.get({query: word},
                 function success(response) {
                     //alert($scope.challenge.question);
@@ -93,8 +93,8 @@ mudrodControllers.controller('metadataViewCtrl', ['$rootScope', '$scope', '$rout
         var opt = new String();
         
         if(!$routeParams.query){
-            word = $rootScope.searchOptions.term;    
-            opt = $rootScope.searchOptions.preference; 
+            word = $rootScope.searchOptions.query;    
+            opt = $rootScope.searchOptions.opt; 
             SearchOptions.setSearchOptions({'query':word, 'opt':opt});
         } else {
             word = $routeParams.query;
@@ -121,7 +121,7 @@ mudrodControllers.controller('metadataViewCtrl', ['$rootScope', '$scope', '$rout
             } 
             
             if(!$rootScope.searchOptions) $rootScope.searchOptions = {};
-            $rootScope.searchOptions.term = searchKeyWords;
+            $rootScope.searchOptions.query = searchKeyWords;
             word = searchKeyWords;
             //opt = 'And';
         }
@@ -163,7 +163,7 @@ mudrodControllers.controller('metadataViewCtrl', ['$rootScope', '$scope', '$rout
                 }
             } 
             
-            $rootScope.searchOptions.term = searchKeyWords;
+            $rootScope.searchOptions.query = searchKeyWords;
             MetaData.get({query: searchKeyWords, operator: opt}, 
                 function success(response) {
                     vm.PDItems = response.PDResults;
@@ -203,8 +203,8 @@ mudrodControllers.controller('datasetViewCtrl', ['$scope', '$routeParams', 'Data
         var query = new String();
         var opt = new String();
         if(!$routeParams.query){
-        	query = $rootScope.searchOptions.term;    
-            opt = $rootScope.searchOptions.preference; 
+        	query = $rootScope.searchOptions.query;    
+            opt = $rootScope.searchOptions.opt; 
             SearchOptions.setSearchOptions({'query':query, 'opt':opt});
         } else {
         	query = $routeParams.query;

--- a/web/META-INF/resources/js/controllers.js
+++ b/web/META-INF/resources/js/controllers.js
@@ -17,8 +17,8 @@
 /* Controllers */
 var mudrodControllers = angular.module('mudrodControllers', []);
 
-mudrodControllers.controller('searchCtrl', ['$scope', '$rootScope', '$location', 'Autocomplete',
-    function ($scope, $rootScope, $location, Autocomplete) {
+mudrodControllers.controller('searchCtrl', ['$scope', '$rootScope', '$location', 'Autocomplete', 'SearchOptions', 
+    function ($scope, $rootScope, $location, Autocomplete, SearchOptions) {
         $scope.options = {
             preference: 'And'
         };
@@ -27,7 +27,7 @@ mudrodControllers.controller('searchCtrl', ['$scope', '$rootScope', '$location',
         
         $scope.complete = function(string) {  
             $scope.hidethis = false;  
-            $scope.hideoption = true;
+            $scope.hideoption = false;
             var output = [];  
             Autocomplete.get({term: string},
                 function success(response) {
@@ -51,11 +51,15 @@ mudrodControllers.controller('searchCtrl', ['$scope', '$rootScope', '$location',
 
         $scope.search = function(options) {
             $rootScope.searchOptions = angular.copy(options);
-            
-            $location.path("/metadataView/"+options.term);
-
+            $location.path("/metadataView/" + options.term + '/' + options.preference);
         };
 
+        $scope.$watch(function () { return SearchOptions.getSearchOptions(); }, function (newValue, oldValue) {
+            if (newValue != null) {
+                $scope.options.term= newValue.query;
+                $scope.options.preference= newValue.opt;
+            }
+        }, true);
     }]);
     
 mudrodControllers.controller('vocabularyCtrl', ['$scope', '$rootScope', 'VocabList',
@@ -77,8 +81,8 @@ mudrodControllers.controller('vocabularyCtrl', ['$scope', '$rootScope', 'VocabLi
         );
     }]);
 
-mudrodControllers.controller('metadataViewCtrl', ['$rootScope', '$scope', '$routeParams', 'MetaData', 'PagerService',
-    function metadataViewCtrl($rootScope, $scope, $routeParams, MetaData, PagerService) {
+mudrodControllers.controller('metadataViewCtrl', ['$rootScope', '$scope', '$routeParams', 'MetaData', 'PagerService', 'SearchOptions', 
+    function metadataViewCtrl($rootScope, $scope, $routeParams, MetaData, PagerService, SearchOptions) {
         var vm = this;
         vm.PDItems = [];
         vm.pager = {};
@@ -88,11 +92,15 @@ mudrodControllers.controller('metadataViewCtrl', ['$rootScope', '$scope', '$rout
         var word = new String();
         var opt = new String();
         
-        if(!$routeParams.name){
+        if(!$routeParams.query){
             word = $rootScope.searchOptions.term;    
             opt = $rootScope.searchOptions.preference; 
+            SearchOptions.setSearchOptions({'query':word, 'opt':opt});
         } else {
-            word = $routeParams.name;
+            word = $routeParams.query;
+            opt = $routeParams.opt;
+            SearchOptions.setSearchOptions({'query':word, 'opt':opt});
+            
             var searchKeyWords = new String();
 
             if (word.search(',') != -1) {
@@ -111,9 +119,11 @@ mudrodControllers.controller('metadataViewCtrl', ['$rootScope', '$scope', '$rout
                     searchKeyWords += topics[i];
                 }
             } 
+            
+            if(!$rootScope.searchOptions) $rootScope.searchOptions = {};
             $rootScope.searchOptions.term = searchKeyWords;
             word = searchKeyWords;
-            opt = 'And';
+            //opt = 'And';
         }
 
         function initController() {
@@ -158,6 +168,8 @@ mudrodControllers.controller('metadataViewCtrl', ['$rootScope', '$scope', '$rout
                 function success(response) {
                     vm.PDItems = response.PDResults;
                     vm.totalMatches = vm.PDItems.length;
+                    vm.query = word;
+                    vm.opt = opt;
                     initController();
                     //$scope.PDResults = response.PDResults;
 
@@ -172,6 +184,8 @@ mudrodControllers.controller('metadataViewCtrl', ['$rootScope', '$scope', '$rout
                 function success(response) {
                     vm.PDItems = response.PDResults;
                     vm.totalMatches = vm.PDItems.length;
+                    vm.query = word;
+                    vm.opt = opt;
                     initController();
                     //$scope.PDResults = response.PDResults;
 
@@ -182,10 +196,22 @@ mudrodControllers.controller('metadataViewCtrl', ['$rootScope', '$scope', '$rout
         );
     }]);
 
-mudrodControllers.controller('datasetViewCtrl', ['$scope', '$routeParams', 'DatasetDetail',
-    function datasetViewCtrl($scope, $routeParams, DatasetDetail) {
+mudrodControllers.controller('datasetViewCtrl', ['$scope', '$routeParams', 'DatasetDetail', 'SearchOptions',
+    function datasetViewCtrl($scope, $routeParams, DatasetDetail, SearchOptions) {
         var shortname = $routeParams.shortname;   
-
+        
+        var query = new String();
+        var opt = new String();
+        if(!$routeParams.query){
+        	query = $rootScope.searchOptions.term;    
+            opt = $rootScope.searchOptions.preference; 
+            SearchOptions.setSearchOptions({'query':query, 'opt':opt});
+        } else {
+        	query = $routeParams.query;
+            opt = $routeParams.opt;
+            SearchOptions.setSearchOptions({'query':query, 'opt':opt});
+        }
+        
         DatasetDetail.get({shortname: shortname}, 
                 function success(response) {
                     var dataAccessUrls;

--- a/web/META-INF/resources/js/services.js
+++ b/web/META-INF/resources/js/services.js
@@ -53,6 +53,18 @@ mudrodServices.factory('HRecommendation', ['$resource',
         });
     }]);
 
+mudrodServices.factory('SearchOptions', function(){
+	var searchOptions = {'preference':'And'};
+	return {
+	    getSearchOptions: function () {
+	        return searchOptions;
+	    },
+	    setSearchOptions: function (value) {
+	    	searchOptions = value;
+	    }
+	};
+});
+
 mudrodServices.factory('PagerService',
     function() {
         // service definition

--- a/web/META-INF/resources/js/services.js
+++ b/web/META-INF/resources/js/services.js
@@ -54,7 +54,7 @@ mudrodServices.factory('HRecommendation', ['$resource',
     }]);
 
 mudrodServices.factory('SearchOptions', function(){
-	var searchOptions = {'preference':'And'};
+	var searchOptions = {'opt':'And'};
 	return {
 	    getSearchOptions: function () {
 	        return searchOptions;

--- a/web/META-INF/resources/partials/metadataResults.html
+++ b/web/META-INF/resources/partials/metadataResults.html
@@ -22,7 +22,7 @@
             </div>
             <div ng-repeat="pdresult in vm.items">
                 <article class="post">
-                    <a href="#!datasetView/{{pdresult['Short Name']}}"><strong>Name:</strong> {{pdresult['Short Name']}}</a>
+                    <a href="#!datasetView/{{pdresult['Short Name']}}/{{vm.query}}/{{vm.opt}}"><strong>Name:</strong> {{pdresult['Short Name']}}</a>
                     <br><strong>Long Name:</strong> {{pdresult['Long Name']}}
                     <br><strong>Topic:</strong> 
                     <span style="color:green" ng-click="vm.searchTopic(pdresult.Topic)">{{pdresult.Topic}}</span>

--- a/web/META-INF/resources/partials/navbar-search.html
+++ b/web/META-INF/resources/partials/navbar-search.html
@@ -28,7 +28,7 @@
              <form id="searchForm" class="navbar-form navbar-right" autocomplete="off" ng-controller="searchCtrl">
                 <div class="input-group">
 
-                    <input id="query" type="search" class="form-control" ng-model="options.term" ng-keyup="complete(options.term)"
+                    <input id="query" type="search" class="form-control" ng-model="options.query" ng-keyup="complete(options.query)"
                             placeholder="Enter ocean concepts (e.g. ocean wind) to search" style="width: 350px">
                     <ul class="list-group serch-ul" ng-model="hidethis" ng-hide="hidethis" style="width: 350px">  
                         <li class="list-group-item" ng-repeat="searchdata in filterSearch" ng-click="fillTextbox(searchdata.value)">{{searchdata.value}}</li>  
@@ -46,13 +46,13 @@
                 <div class="searchOption input-group" id="searchOption">
                     <span>Search Operator: </span>
                     <label class="radio-inline">
-                        <input type="radio" ng-model="options.preference" value="Phrase"> Phrase 
+                        <input type="radio" ng-model="options.opt" value="Phrase"> Phrase 
                     </label>
                     <label class="radio-inline">
-                        <input type="radio" ng-model="options.preference" value="And"> And 
+                        <input type="radio" ng-model="options.opt" value="And"> And 
                     </label>
                     <lable class="radio-inline"> 
-                        <input type="radio" ng-model="options.preference" value="Or">Or
+                        <input type="radio" ng-model="options.opt" value="Or">Or
                     </lable>
                 </div>
             </form>

--- a/web/META-INF/resources/partials/search.html
+++ b/web/META-INF/resources/partials/search.html
@@ -23,7 +23,7 @@
                 <form id="searchForm" class="search-form" autocomplete="off" ng-controller="searchCtrl">
                     <div class="form-group">
 
-                        <input id="query" type="search" class="form-control" ng-model="options.term" ng-keyup="complete(options.term)"
+                        <input id="query" type="search" class="form-control" ng-model="options.query" ng-keyup="complete(options.query)"
                                 placeholder="Enter ocean concepts (e.g. ocean wind) to search">
                         <button id="search-btn" ng-click="search(options)"
                                 type="submit">
@@ -36,13 +36,13 @@
                     <div id="searchOption" ng-model="hideoption" ng-hide="hideoption">
                         <span>Search Operator: </span>
                         <label class="radio-inline">
-                            <input type="radio" ng-model="options.preference" value="Phrase"> Phrase 
+                            <input type="radio" ng-model="options.opt" value="Phrase"> Phrase 
                         </label>
                         <label class="radio-inline">
-                            <input type="radio" ng-model="options.preference" value="And"> And 
+                            <input type="radio" ng-model="options.opt" value="And"> And 
                         </label>
                         <lable class="radio-inline"> 
-                            <input type="radio" ng-model="options.preference" value="Or">Or
+                            <input type="radio" ng-model="options.opt" value="Or">Or
                         </lable>
                     </div>
                 </form>


### PR DESCRIPTION
1. keep search operator options when a query is executed from index.html
2. remain query and operator in the search bar in dataset list and detail page.
3. use chosen search operator to search data 

@lewismc @fgreg @gxtchen Honestly, I never used AngularJS before and I just learned it yesterday. Thus my implementation might not be professional enough. Please let me know if any problem. Thanks.