### PR TITLE
add Hyperlink to DOI Value

### DIFF
--- a/web/META-INF/resources/partials/datasetResults.html
+++ b/web/META-INF/resources/partials/datasetResults.html
@@ -34,7 +34,7 @@
                         </tr>
                         <tr>
                             <td>DOI</td>
-                            <td>{{dataset['Dataset-Doi']}}</td>
+                            <td><a href="https://podaac.jpl.nasa.gov/dataset/{{dataset['Short Name']}}" target="_blank">{{dataset['Dataset-Doi']}}</a></td>
                         </tr>
                         <tr>
                             <td>Measurement</td>


### PR DESCRIPTION
Make the DOI value a hyperlink to the PO.DAAC landing page for the dataset.